### PR TITLE
feat: 月固定費の記録・管理機能を追加

### DIFF
--- a/src/components/Summary/FixedCostItemDialog.tsx
+++ b/src/components/Summary/FixedCostItemDialog.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  Typography,
+  Alert,
+  Box,
+} from '@mui/material';
+import type { FixedCostItem } from '../../types';
+import {
+  addFixedCostItem,
+  clearAmountChange,
+  endFixedCostItem,
+  renameFixedCostItem,
+  setAmountForMonth,
+  useFixedCostAmountChanges,
+} from '../../hooks/useFixedCosts';
+import {
+  formatYearMonthLabel,
+  resolveAmountForMonth,
+} from '../../utils/fixedCost';
+import { formatCurrency } from '../../utils/format';
+
+type DialogMode = 'add' | 'edit';
+
+interface FixedCostItemDialogProps {
+  open: boolean;
+  mode: DialogMode;
+  item: FixedCostItem | null; // mode === 'edit' のとき必須
+  yearMonth: string; // "YYYY-MM"
+  onClose: () => void;
+}
+
+export function FixedCostItemDialog({
+  open,
+  mode,
+  item,
+  yearMonth,
+  onClose,
+}: FixedCostItemDialogProps) {
+  const changes = useFixedCostAmountChanges();
+  const [nameInput, setNameInput] = useState<string>('');
+  const [amountInput, setAmountInput] = useState<string>('');
+  const [error, setError] = useState<string | null>(null);
+
+  // edit モード時の現在金額と発効月
+  const resolved =
+    mode === 'edit' && item
+      ? resolveAmountForMonth(item, changes, yearMonth)
+      : null;
+
+  // この月に紐づく変更レコードが存在するか（「この月の変更を取り消す」ボタン表示判定）
+  const hasChangeForThisMonth =
+    mode === 'edit' && item
+      ? changes.some(
+          (c) =>
+            c.itemId === item.id &&
+            c.effectiveYearMonth === yearMonth &&
+            !c.deleted,
+        )
+      : false;
+
+  useEffect(() => {
+    if (!open) return;
+    if (mode === 'edit' && item && resolved) {
+      setNameInput(item.name);
+      setAmountInput(String(resolved.amount));
+    } else {
+      setNameInput('');
+      setAmountInput('');
+    }
+    setError(null);
+    // open, mode, item.id のみ依存。resolved は毎回変わるので除外。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, mode, item?.id]);
+
+  const handleSave = async () => {
+    const name = nameInput.trim();
+    const amount = parseInt(amountInput, 10);
+    if (!name) {
+      setError('項目名を入力してください');
+      return;
+    }
+    if (isNaN(amount) || amount < 0) {
+      setError('金額は0以上の整数を入力してください');
+      return;
+    }
+
+    try {
+      setError(null);
+      if (mode === 'add') {
+        await addFixedCostItem(name, amount, yearMonth);
+      } else if (mode === 'edit' && item) {
+        if (name !== item.name) {
+          await renameFixedCostItem(item.id, name);
+        }
+        if (resolved && amount !== resolved.amount) {
+          await setAmountForMonth(item.id, yearMonth, amount);
+        }
+      }
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '保存に失敗しました');
+    }
+  };
+
+  const handleDelete = async () => {
+    if (mode !== 'edit' || !item) return;
+    const msg =
+      item.startYearMonth === yearMonth
+        ? `「${item.name}」を削除しますか？\n（過去月のデータがないため完全に消えます）`
+        : `「${item.name}」を${formatYearMonthLabel(yearMonth)}以降から削除しますか？\n（${formatYearMonthLabel(yearMonth)}より前の月には残ります）`;
+    if (!window.confirm(msg)) return;
+    try {
+      setError(null);
+      await endFixedCostItem(item.id, yearMonth);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '削除に失敗しました');
+    }
+  };
+
+
+  const handleClearChange = async () => {
+    if (mode !== 'edit' || !item) return;
+    try {
+      setError(null);
+      await clearAmountChange(item.id, yearMonth);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '取り消しに失敗しました');
+    }
+  };
+
+  const title = mode === 'add' ? '固定費を追加' : `${item?.name ?? ''} を編集`;
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>{title}</DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          対象月: {formatYearMonthLabel(yearMonth)}
+        </Typography>
+
+        {mode === 'edit' && resolved && (
+          <Typography variant="body2" sx={{ mb: 2 }}>
+            現在: {formatCurrency(resolved.amount)}（
+            {resolved.changedFrom
+              ? `${formatYearMonthLabel(resolved.changedFrom)}以降の金額`
+              : '初期金額'}
+            ）
+          </Typography>
+        )}
+
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          <TextField
+            fullWidth
+            label="項目名"
+            value={nameInput}
+            onChange={(e) => setNameInput(e.target.value)}
+            autoFocus={mode === 'add'}
+          />
+          <TextField
+            fullWidth
+            label="金額（円）"
+            type="number"
+            value={amountInput}
+            onChange={(e) => setAmountInput(e.target.value)}
+            inputProps={{ min: 0, step: 1 }}
+          />
+        </Box>
+
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          display="block"
+          sx={{ mt: 1 }}
+        >
+          {mode === 'add'
+            ? `${formatYearMonthLabel(yearMonth)}以降のすべての月に表示されます。`
+            : `金額変更は${formatYearMonthLabel(yearMonth)}以降に適用されます（次の変更があればそこで上書き）。`}
+        </Typography>
+
+        {error && (
+          <Alert severity="error" sx={{ mt: 2 }}>
+            {error}
+          </Alert>
+        )}
+      </DialogContent>
+      <DialogActions sx={{ flexWrap: 'wrap', gap: 1, px: 3, pb: 2 }}>
+        {mode === 'edit' && (
+          <Button onClick={handleDelete} color="error">
+            削除
+          </Button>
+        )}
+        {hasChangeForThisMonth && (
+          <Button onClick={handleClearChange} color="secondary">
+            この月の変更を取り消す
+          </Button>
+        )}
+        <Box sx={{ flexGrow: 1 }} />
+        <Button onClick={onClose}>キャンセル</Button>
+        <Button onClick={handleSave} variant="contained">
+          保存
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/Summary/MonthlySummary.tsx
+++ b/src/components/Summary/MonthlySummary.tsx
@@ -3,12 +3,22 @@ import { Box, IconButton, Typography, List, ListItem, ListItemText, Divider, But
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import TodayIcon from '@mui/icons-material/Today';
+import EditIcon from '@mui/icons-material/Edit';
+import AddIcon from '@mui/icons-material/Add';
 import { useExpensesByMonth } from '../../hooks/useExpenses';
+import { useMonthlyFixedCosts } from '../../hooks/useFixedCosts';
 import { formatCurrency } from '../../utils/format';
 import { toDateString } from '../../utils/date';
+import {
+  formatYearMonth,
+  formatYearMonthLabel,
+  isPastYearMonth,
+} from '../../utils/fixedCost';
 import { aggregateByCategory } from '../../utils/chart';
 import { CategoryDonutChart } from './CategoryDonutChart';
 import { ExpenseListSection } from './ExpenseListSection';
+import { FixedCostItemDialog } from './FixedCostItemDialog';
+import type { FixedCostItem } from '../../types';
 
 interface WeekBreakdown {
   label: string;
@@ -60,8 +70,16 @@ export function MonthlySummary({ includeSpecial }: MonthlySummaryProps) {
   const today = new Date();
   const [year, setYear] = useState(today.getFullYear());
   const [month, setMonth] = useState(today.getMonth());
+  const [fixedCostDialogMode, setFixedCostDialogMode] =
+    useState<'add' | 'edit' | null>(null);
+  const [fixedCostDialogItem, setFixedCostDialogItem] =
+    useState<FixedCostItem | null>(null);
 
   const expenses = useExpensesByMonth(year, month);
+  const yearMonth = formatYearMonth(year, month);
+  const isPast = isPastYearMonth(yearMonth, today);
+  const { resolved: fixedCosts, total: fixedCostTotal } =
+    useMonthlyFixedCosts(yearMonth);
 
   // 前月のデータを取得
   const prevMonth = month === 0 ? 11 : month - 1;
@@ -165,10 +183,20 @@ export function MonthlySummary({ includeSpecial }: MonthlySummaryProps) {
               mt: 0.5,
             }}
           >
-            前月比: {monthDiff > 0 ? '+' : ''}
+            前月比（月合計）: {monthDiff > 0 ? '+' : ''}
             {formatCurrency(monthDiff)} ({monthDiff > 0 ? '+' : ''}
             {monthDiffPercent}%)
           </Typography>
+        )}
+        {fixedCosts.length > 0 && (
+          <>
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+              固定費: {formatCurrency(fixedCostTotal)}
+            </Typography>
+            <Typography variant="body2" fontWeight="bold" sx={{ mt: 0.5 }}>
+              月合計 + 固定費: {formatCurrency(monthTotal + fixedCostTotal)}
+            </Typography>
+          </>
         )}
       </Box>
 
@@ -189,8 +217,87 @@ export function MonthlySummary({ includeSpecial }: MonthlySummaryProps) {
         ))}
       </List>
 
+      {/* 月固定費の内訳 */}
+      {(fixedCosts.length > 0 || !isPast) && (
+        <>
+          <Divider>
+            <Typography variant="caption">固定費の内訳</Typography>
+          </Divider>
+          {fixedCosts.length > 0 ? (
+            <List dense>
+              {fixedCosts.map(({ item, amount, changedFrom }) => (
+                <ListItem
+                  key={item.id}
+                  secondaryAction={
+                    !isPast && (
+                      <IconButton
+                        edge="end"
+                        size="small"
+                        onClick={() => {
+                          setFixedCostDialogItem(item);
+                          setFixedCostDialogMode('edit');
+                        }}
+                        aria-label={`${item.name}を編集`}
+                      >
+                        <EditIcon fontSize="small" />
+                      </IconButton>
+                    )
+                  }
+                >
+                  <ListItemText
+                    primary={item.name}
+                    secondary={
+                      changedFrom
+                        ? `${formatYearMonthLabel(changedFrom)}以降の金額`
+                        : '初期金額'
+                    }
+                  />
+                  <Typography variant="body2" sx={{ mr: isPast ? 0 : 5 }}>
+                    {formatCurrency(amount)}
+                  </Typography>
+                </ListItem>
+              ))}
+            </List>
+          ) : (
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ textAlign: 'center', py: 2 }}
+            >
+              固定費は登録されていません
+            </Typography>
+          )}
+          {!isPast && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
+              <Button
+                size="small"
+                variant="outlined"
+                startIcon={<AddIcon />}
+                onClick={() => {
+                  setFixedCostDialogItem(null);
+                  setFixedCostDialogMode('add');
+                }}
+              >
+                項目を追加
+              </Button>
+            </Box>
+          )}
+        </>
+      )}
+
       {/* 支出一覧（メモ確認用） */}
       <ExpenseListSection expenses={filteredExpenses} />
+
+      <FixedCostItemDialog
+        open={fixedCostDialogMode !== null}
+        mode={fixedCostDialogMode ?? 'add'}
+        item={fixedCostDialogItem}
+        yearMonth={yearMonth}
+        onClose={() => {
+          setFixedCostDialogMode(null);
+          setFixedCostDialogItem(null);
+        }}
+      />
     </Box>
   );
 }

--- a/src/components/Summary/SummaryView.tsx
+++ b/src/components/Summary/SummaryView.tsx
@@ -25,8 +25,8 @@ export function SummaryView() {
         centered
         sx={{ mb: { xs: 2, sm: 3 } }}
       >
-        <Tab label="週次" />
         <Tab label="月次" />
+        <Tab label="週次" />
       </Tabs>
 
       {/* 特別な支出フィルタ */}
@@ -43,8 +43,8 @@ export function SummaryView() {
         />
       </Box>
 
-      {tab === 0 && <WeeklySummary includeSpecial={includeSpecial} />}
-      {tab === 1 && <MonthlySummary includeSpecial={includeSpecial} />}
+      {tab === 0 && <MonthlySummary includeSpecial={includeSpecial} />}
+      {tab === 1 && <WeeklySummary includeSpecial={includeSpecial} />}
     </Box>
   );
 }

--- a/src/hooks/useFixedCosts.ts
+++ b/src/hooks/useFixedCosts.ts
@@ -1,0 +1,160 @@
+import { useLiveQuery } from 'dexie-react-hooks';
+import { db } from '../services/db';
+import type { FixedCostAmountChange, FixedCostItem } from '../types';
+import {
+  resolveMonthlyFixedCosts,
+  sumMonthlyFixedCosts,
+  type ResolvedFixedCost,
+} from '../utils/fixedCost';
+
+// アクティブな固定費項目一覧（論理削除除外、order昇順）
+export function useFixedCostItems(): FixedCostItem[] {
+  return useLiveQuery(
+    () =>
+      db.fixedCostItems
+        .filter((i) => !i.deleted)
+        .toArray()
+        .then((items) => items.sort((a, b) => a.order - b.order)),
+    [],
+    [],
+  );
+}
+
+// 全変更履歴（削除済みを含む全て、解決ロジックでフィルタリング）
+export function useFixedCostAmountChanges(): FixedCostAmountChange[] {
+  return useLiveQuery(() => db.fixedCostAmountChanges.toArray(), [], []);
+}
+
+export interface MonthlyFixedCostsResult {
+  resolved: ResolvedFixedCost[];
+  total: number;
+}
+
+// 指定月（"YYYY-MM"）の固定費一覧と合計
+export function useMonthlyFixedCosts(
+  yearMonth: string,
+): MonthlyFixedCostsResult {
+  const items = useFixedCostItems();
+  const changes = useFixedCostAmountChanges();
+  const resolved = resolveMonthlyFixedCosts(items, changes, yearMonth);
+  return { resolved, total: sumMonthlyFixedCosts(resolved) };
+}
+
+// 項目を追加
+// order はタイムスタンプ + ランダム値の複合（異デバイス同秒追加でも衝突ほぼなし）。
+// 新しい項目ほど末尾に並ぶ。
+// startYearMonth 以降の月でのみ表示・集計される。
+export async function addFixedCostItem(
+  name: string,
+  initialAmount: number,
+  startYearMonth: string,
+): Promise<void> {
+  const now = new Date().toISOString();
+  await db.fixedCostItems.add({
+    id: crypto.randomUUID(),
+    name,
+    initialAmount,
+    startYearMonth,
+    order: Date.now() * 1000 + Math.floor(Math.random() * 1000),
+    updatedAt: now,
+  });
+}
+
+// 項目の名前だけ更新（全月に影響）
+export async function renameFixedCostItem(
+  id: string,
+  name: string,
+): Promise<void> {
+  await db.fixedCostItems.update(id, {
+    name,
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+// 指定月以降の金額を設定する（effective-from 方式）
+// - 常に fixedCostAmountChanges に 1 レコードを作成/更新する
+// - initialAmount（項目作成時の金額）は不変。変更はすべて change レコードで履歴管理
+// - 既存の同月 change があれば amount を上書き、なければ新規追加
+export async function setAmountForMonth(
+  itemId: string,
+  yearMonth: string,
+  amount: number,
+): Promise<void> {
+  const now = new Date().toISOString();
+  const existing = await db.fixedCostAmountChanges
+    .where('[itemId+effectiveYearMonth]')
+    .equals([itemId, yearMonth])
+    .filter((c) => !c.deleted)
+    .first();
+
+  if (existing) {
+    await db.fixedCostAmountChanges.update(existing.id, {
+      amount,
+      updatedAt: now,
+    });
+    return;
+  }
+
+  await db.fixedCostAmountChanges.add({
+    id: crypto.randomUUID(),
+    itemId,
+    effectiveYearMonth: yearMonth,
+    amount,
+    updatedAt: now,
+  });
+}
+
+// 項目を「この月以降」終了させる（過去月には残る）
+// - startYearMonth === yearMonth の場合: 過去データが一切ないので deleted: true で完全削除
+//   （sync 時に物理削除される。endYearMonth だけ立てると孤立レコードが永遠に運ばれる）
+//   関連する fixedCostAmountChanges も論理削除して Dropbox に孤立レコードを残さない
+// - それ以外: endYearMonth = yearMonth を設定し、yearMonth以降は非表示
+export async function endFixedCostItem(
+  id: string,
+  yearMonth: string,
+): Promise<void> {
+  const item = await db.fixedCostItems.get(id);
+  if (!item) throw new Error(`固定費項目が見つかりません: ${id}`);
+  const now = new Date().toISOString();
+
+  if (item.startYearMonth === yearMonth) {
+    await db.fixedCostItems.update(id, {
+      deleted: true,
+      updatedAt: now,
+    });
+    // 参照整合性: 項目を完全削除する際は関連 change もすべて論理削除
+    await db.fixedCostAmountChanges
+      .where('itemId')
+      .equals(id)
+      .filter((c) => !c.deleted)
+      .modify((c) => {
+        c.deleted = true;
+        c.updatedAt = now;
+      });
+    return;
+  }
+
+  await db.fixedCostItems.update(id, {
+    endYearMonth: yearMonth,
+    updatedAt: now,
+  });
+}
+
+// 「この月以降」の金額変更を論理削除（前の金額に戻す）
+export async function clearAmountChange(
+  itemId: string,
+  effectiveYearMonth: string,
+): Promise<void> {
+  const existing = await db.fixedCostAmountChanges
+    .where('[itemId+effectiveYearMonth]')
+    .equals([itemId, effectiveYearMonth])
+    .filter((c) => !c.deleted)
+    .first();
+
+  if (!existing) return;
+
+  await db.fixedCostAmountChanges.update(existing.id, {
+    deleted: true,
+    updatedAt: new Date().toISOString(),
+  });
+}

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -1,10 +1,18 @@
 import Dexie, { type Table } from 'dexie';
-import type { Expense, Metadata, WeekBudget } from '../types';
+import type {
+  Expense,
+  FixedCostAmountChange,
+  FixedCostItem,
+  Metadata,
+  WeekBudget,
+} from '../types';
 
 export class SeihinDB extends Dexie {
   expenses!: Table<Expense, string>;
   metadata!: Table<Metadata, string>;
   weekBudgets!: Table<WeekBudget, string>;
+  fixedCostItems!: Table<FixedCostItem, string>;
+  fixedCostAmountChanges!: Table<FixedCostAmountChange, string>;
 
   constructor() {
     super('seihin');
@@ -92,6 +100,48 @@ export class SeihinDB extends Dexie {
             }
           });
       });
+
+    // v7: 月固定費テーブル追加
+    this.version(7).stores({
+      expenses: 'id, date, category, createdAt, updatedAt',
+      metadata: 'key',
+      weekBudgets: 'weekStart',
+      fixedCostItems: 'id, order, updatedAt',
+      fixedCostAmountChanges:
+        'id, itemId, effectiveYearMonth, updatedAt, [itemId+effectiveYearMonth]',
+    });
+
+    // v8: FixedCostItem に startYearMonth フィールドを追加
+    this.version(8)
+      .stores({
+        expenses: 'id, date, category, createdAt, updatedAt',
+        metadata: 'key',
+        weekBudgets: 'weekStart',
+        fixedCostItems: 'id, order, startYearMonth, updatedAt',
+        fixedCostAmountChanges:
+          'id, itemId, effectiveYearMonth, updatedAt, [itemId+effectiveYearMonth]',
+      })
+      .upgrade((tx) => {
+        // 既存レコードには過去月から有効な値を設定（実質的に全月に出現）
+        return tx
+          .table('fixedCostItems')
+          .toCollection()
+          .modify((item) => {
+            if (!item.startYearMonth) {
+              item.startYearMonth = '1970-01';
+            }
+          });
+      });
+
+    // v9: FixedCostItem に endYearMonth フィールドを追加（終了月の管理）
+    this.version(9).stores({
+      expenses: 'id, date, category, createdAt, updatedAt',
+      metadata: 'key',
+      weekBudgets: 'weekStart',
+      fixedCostItems: 'id, order, startYearMonth, endYearMonth, updatedAt',
+      fixedCostAmountChanges:
+        'id, itemId, effectiveYearMonth, updatedAt, [itemId+effectiveYearMonth]',
+    });
   }
 }
 

--- a/src/services/sync.test.ts
+++ b/src/services/sync.test.ts
@@ -1,6 +1,18 @@
 import { describe, it, expect } from 'vitest';
-import { mergeExpenses, mergeWeekBudgets, mergeDefaultWeekBudget } from './sync';
-import type { Expense, WeekBudget, DefaultWeekBudgetSync } from '../types';
+import {
+  mergeExpenses,
+  mergeWeekBudgets,
+  mergeDefaultWeekBudget,
+  mergeFixedCostItems,
+  mergeFixedCostAmountChanges,
+} from './sync';
+import type {
+  Expense,
+  WeekBudget,
+  DefaultWeekBudgetSync,
+  FixedCostItem,
+  FixedCostAmountChange,
+} from '../types';
 
 // テスト用のExpenseヘルパー
 function createExpense(overrides: Partial<Expense> = {}): Expense {
@@ -278,5 +290,182 @@ describe('mergeDefaultWeekBudget', () => {
     const remote: DefaultWeekBudgetSync = { budget: 8000, updatedAt: '2026-02-16T10:00:00Z' };
     const result = mergeDefaultWeekBudget(local, remote);
     expect(result?.budget).toBe(5000);
+  });
+});
+
+function createFixedCostItem(
+  overrides: Partial<FixedCostItem> = {},
+): FixedCostItem {
+  return {
+    id: 'item-1',
+    name: '家賃',
+    initialAmount: 80000,
+    startYearMonth: '2026-04',
+    order: 0,
+    updatedAt: '2026-04-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('mergeFixedCostItems', () => {
+  it('ローカルのみの場合、ローカルをそのまま返す', () => {
+    const local = [createFixedCostItem({ id: '1' })];
+    const result = mergeFixedCostItems(local, []);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('1');
+  });
+
+  it('リモートのみの場合、リモートをそのまま返す', () => {
+    const remote = [createFixedCostItem({ id: '1' })];
+    const result = mergeFixedCostItems([], remote);
+    expect(result).toHaveLength(1);
+  });
+
+  it('両方空の場合、空配列を返す', () => {
+    expect(mergeFixedCostItems([], [])).toHaveLength(0);
+  });
+
+  it('同一IDでリモートが新しい場合、リモートを採用する', () => {
+    const local = [
+      createFixedCostItem({
+        id: '1',
+        initialAmount: 80000,
+        updatedAt: '2026-04-01T10:00:00Z',
+      }),
+    ];
+    const remote = [
+      createFixedCostItem({
+        id: '1',
+        initialAmount: 85000,
+        updatedAt: '2026-04-01T11:00:00Z',
+      }),
+    ];
+    const result = mergeFixedCostItems(local, remote);
+    expect(result).toHaveLength(1);
+    expect(result[0].initialAmount).toBe(85000);
+  });
+
+  it('同一IDでupdatedAtが同じ場合、ローカルを採用する', () => {
+    const local = [
+      createFixedCostItem({
+        id: '1',
+        initialAmount: 80000,
+        updatedAt: '2026-04-01T10:00:00Z',
+      }),
+    ];
+    const remote = [
+      createFixedCostItem({
+        id: '1',
+        initialAmount: 85000,
+        updatedAt: '2026-04-01T10:00:00Z',
+      }),
+    ];
+    const result = mergeFixedCostItems(local, remote);
+    expect(result[0].initialAmount).toBe(80000);
+  });
+
+  it('異なるIDの場合、両方含む', () => {
+    const local = [createFixedCostItem({ id: '1' })];
+    const remote = [createFixedCostItem({ id: '2' })];
+    const result = mergeFixedCostItems(local, remote);
+    expect(result).toHaveLength(2);
+  });
+
+  it('リモートで削除された場合、新しければ削除を採用する', () => {
+    const local = [
+      createFixedCostItem({
+        id: '1',
+        deleted: false,
+        updatedAt: '2026-04-01T10:00:00Z',
+      }),
+    ];
+    const remote = [
+      createFixedCostItem({
+        id: '1',
+        deleted: true,
+        updatedAt: '2026-04-01T11:00:00Z',
+      }),
+    ];
+    const result = mergeFixedCostItems(local, remote);
+    expect(result[0].deleted).toBe(true);
+  });
+});
+
+function createAmountChange(
+  overrides: Partial<FixedCostAmountChange> = {},
+): FixedCostAmountChange {
+  return {
+    id: 'change-1',
+    itemId: 'item-1',
+    effectiveYearMonth: '2026-05',
+    amount: 10000,
+    updatedAt: '2026-04-15T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('mergeFixedCostAmountChanges', () => {
+  it('ローカルのみの場合、ローカルをそのまま返す', () => {
+    const local = [createAmountChange({ id: '1' })];
+    const result = mergeFixedCostAmountChanges(local, []);
+    expect(result).toHaveLength(1);
+  });
+
+  it('リモートのみの場合、リモートをそのまま返す', () => {
+    const remote = [createAmountChange({ id: '1' })];
+    const result = mergeFixedCostAmountChanges([], remote);
+    expect(result).toHaveLength(1);
+  });
+
+  it('同一IDでリモートが新しい場合、リモートを採用する', () => {
+    const local = [
+      createAmountChange({
+        id: '1',
+        amount: 10000,
+        updatedAt: '2026-04-15T10:00:00Z',
+      }),
+    ];
+    const remote = [
+      createAmountChange({
+        id: '1',
+        amount: 11000,
+        updatedAt: '2026-04-15T11:00:00Z',
+      }),
+    ];
+    const result = mergeFixedCostAmountChanges(local, remote);
+    expect(result[0].amount).toBe(11000);
+  });
+
+  it('異なるIDは両方含まれる', () => {
+    const local = [createAmountChange({ id: '1' })];
+    const remote = [createAmountChange({ id: '2', effectiveYearMonth: '2026-09' })];
+    const result = mergeFixedCostAmountChanges(local, remote);
+    expect(result).toHaveLength(2);
+  });
+
+  it('同じ発効月でも id が違えば両方残る（解決ロジック側で処理）', () => {
+    const local = [createAmountChange({ id: '1', effectiveYearMonth: '2026-05' })];
+    const remote = [createAmountChange({ id: '2', effectiveYearMonth: '2026-05' })];
+    const result = mergeFixedCostAmountChanges(local, remote);
+    expect(result).toHaveLength(2);
+  });
+
+  it('リモートで削除された場合、新しければ削除を採用する', () => {
+    const local = [
+      createAmountChange({
+        id: '1',
+        deleted: false,
+        updatedAt: '2026-04-15T10:00:00Z',
+      }),
+    ];
+    const remote = [
+      createAmountChange({
+        id: '1',
+        deleted: true,
+        updatedAt: '2026-04-15T11:00:00Z',
+      }),
+    ];
+    const result = mergeFixedCostAmountChanges(local, remote);
+    expect(result[0].deleted).toBe(true);
   });
 });

--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -1,6 +1,13 @@
 import { db } from './db';
 import { downloadFile, uploadFile } from './dropbox';
-import type { Expense, SeihinData, WeekBudget, DefaultWeekBudgetSync } from '../types';
+import type {
+  Expense,
+  SeihinData,
+  WeekBudget,
+  DefaultWeekBudgetSync,
+  FixedCostItem,
+  FixedCostAmountChange,
+} from '../types';
 
 // マージロジック: 両方のリストをID基準でマージ
 export function mergeExpenses(
@@ -89,6 +96,48 @@ function extractRemoteWeekBudgets(data: SeihinData): WeekBudget[] {
   }));
 }
 
+// 固定費項目のマージ: idをキーにupdatedAtで新しい方を採用
+export function mergeFixedCostItems(
+  local: FixedCostItem[],
+  remote: FixedCostItem[],
+): FixedCostItem[] {
+  const merged = new Map<string, FixedCostItem>();
+
+  for (const item of local) {
+    merged.set(item.id, item);
+  }
+
+  for (const item of remote) {
+    const existing = merged.get(item.id);
+    if (!existing || item.updatedAt > existing.updatedAt) {
+      merged.set(item.id, item);
+    }
+  }
+
+  return Array.from(merged.values());
+}
+
+// 固定費変更履歴のマージ: idをキーにupdatedAtで新しい方を採用
+export function mergeFixedCostAmountChanges(
+  local: FixedCostAmountChange[],
+  remote: FixedCostAmountChange[],
+): FixedCostAmountChange[] {
+  const merged = new Map<string, FixedCostAmountChange>();
+
+  for (const c of local) {
+    merged.set(c.id, c);
+  }
+
+  for (const c of remote) {
+    const existing = merged.get(c.id);
+    if (!existing || c.updatedAt > existing.updatedAt) {
+      merged.set(c.id, c);
+    }
+  }
+
+  return Array.from(merged.values());
+}
+
 // 同期の排他制御用フラグ
 let isSyncing = false;
 
@@ -104,6 +153,8 @@ export async function performSync(): Promise<void> {
     const localExpenses = await db.expenses.toArray();
     const localWeekBudgets = await db.weekBudgets.toArray();
     const localDefaultWB = await getLocalDefaultWeekBudget();
+    const localFixedCostItems = await db.fixedCostItems.toArray();
+    const localFixedCostChanges = await db.fixedCostAmountChanges.toArray();
 
     // 2. Dropboxからダウンロード
     const downloaded = await downloadFile();
@@ -111,6 +162,8 @@ export async function performSync(): Promise<void> {
     let mergedExpenses: Expense[];
     let mergedWeekBudgets: WeekBudget[];
     let mergedDefaultWB: DefaultWeekBudgetSync | null;
+    let mergedFixedCostItems: FixedCostItem[];
+    let mergedFixedCostChanges: FixedCostAmountChange[];
     let rev: string | undefined;
 
     if (downloaded) {
@@ -122,37 +175,62 @@ export async function performSync(): Promise<void> {
       }));
       const remoteWeekBudgets = extractRemoteWeekBudgets(downloaded.data);
       const remoteDefaultWB = downloaded.data.defaultWeekBudget ?? null;
+      const remoteFixedCostItems = downloaded.data.fixedCostItems ?? [];
+      const remoteFixedCostChanges = downloaded.data.fixedCostAmountChanges ?? [];
 
       // 3. マージ
       mergedExpenses = mergeExpenses(localExpenses, remoteExpenses);
       mergedWeekBudgets = mergeWeekBudgets(localWeekBudgets, remoteWeekBudgets);
       mergedDefaultWB = mergeDefaultWeekBudget(localDefaultWB, remoteDefaultWB);
+      mergedFixedCostItems = mergeFixedCostItems(
+        localFixedCostItems,
+        remoteFixedCostItems,
+      );
+      mergedFixedCostChanges = mergeFixedCostAmountChanges(
+        localFixedCostChanges,
+        remoteFixedCostChanges,
+      );
       rev = downloaded.rev;
     } else {
       // Dropboxにファイルがない場合はローカルのみ
       mergedExpenses = localExpenses;
       mergedWeekBudgets = localWeekBudgets;
       mergedDefaultWB = localDefaultWB;
+      mergedFixedCostItems = localFixedCostItems;
+      mergedFixedCostChanges = localFixedCostChanges;
     }
 
     // 4. ローカルに保存（一括置換）
-    await db.transaction('rw', db.expenses, db.weekBudgets, async () => {
-      await db.expenses.clear();
-      await db.expenses.bulkAdd(mergedExpenses);
-      await db.weekBudgets.clear();
-      await db.weekBudgets.bulkAdd(mergedWeekBudgets);
-    });
+    await db.transaction(
+      'rw',
+      db.expenses,
+      db.weekBudgets,
+      db.fixedCostItems,
+      db.fixedCostAmountChanges,
+      async () => {
+        await db.expenses.clear();
+        await db.expenses.bulkAdd(mergedExpenses);
+        await db.weekBudgets.clear();
+        await db.weekBudgets.bulkAdd(mergedWeekBudgets);
+        await db.fixedCostItems.clear();
+        await db.fixedCostItems.bulkAdd(mergedFixedCostItems);
+        await db.fixedCostAmountChanges.clear();
+        await db.fixedCostAmountChanges.bulkAdd(mergedFixedCostChanges);
+      },
+    );
     if (mergedDefaultWB) {
       await saveLocalDefaultWeekBudget(mergedDefaultWB);
     }
 
     // 5. Dropboxにアップロード
     const dataToUpload: SeihinData = {
-      version: 3,
+      version: 4,
       updatedAt: new Date().toISOString(),
       expenses: mergedExpenses,
       weekBudgets: mergedWeekBudgets,
       defaultWeekBudget: mergedDefaultWB ?? undefined,
+      fixedCostItems: mergedFixedCostItems,
+      fixedCostAmountChanges: mergedFixedCostChanges,
     };
 
     try {
@@ -169,27 +247,50 @@ export async function performSync(): Promise<void> {
           }));
           const retryRemoteWB = extractRemoteWeekBudgets(retryDownload.data);
           const retryRemoteDefaultWB = retryDownload.data.defaultWeekBudget ?? null;
+          const retryRemoteFCI = retryDownload.data.fixedCostItems ?? [];
+          const retryRemoteFCC = retryDownload.data.fixedCostAmountChanges ?? [];
 
           const retryMergedExpenses = mergeExpenses(mergedExpenses, retryRemote);
           const retryMergedWB = mergeWeekBudgets(mergedWeekBudgets, retryRemoteWB);
           const retryMergedDefaultWB = mergeDefaultWeekBudget(mergedDefaultWB, retryRemoteDefaultWB);
+          const retryMergedFCI = mergeFixedCostItems(
+            mergedFixedCostItems,
+            retryRemoteFCI,
+          );
+          const retryMergedFCC = mergeFixedCostAmountChanges(
+            mergedFixedCostChanges,
+            retryRemoteFCC,
+          );
 
-          await db.transaction('rw', db.expenses, db.weekBudgets, async () => {
-            await db.expenses.clear();
-            await db.expenses.bulkAdd(retryMergedExpenses);
-            await db.weekBudgets.clear();
-            await db.weekBudgets.bulkAdd(retryMergedWB);
-          });
+          await db.transaction(
+            'rw',
+            db.expenses,
+            db.weekBudgets,
+            db.fixedCostItems,
+            db.fixedCostAmountChanges,
+            async () => {
+              await db.expenses.clear();
+              await db.expenses.bulkAdd(retryMergedExpenses);
+              await db.weekBudgets.clear();
+              await db.weekBudgets.bulkAdd(retryMergedWB);
+              await db.fixedCostItems.clear();
+              await db.fixedCostItems.bulkAdd(retryMergedFCI);
+              await db.fixedCostAmountChanges.clear();
+              await db.fixedCostAmountChanges.bulkAdd(retryMergedFCC);
+            },
+          );
           if (retryMergedDefaultWB) {
             await saveLocalDefaultWeekBudget(retryMergedDefaultWB);
           }
 
           const retryData: SeihinData = {
-            version: 3,
+            version: 4,
             updatedAt: new Date().toISOString(),
             expenses: retryMergedExpenses,
             weekBudgets: retryMergedWB,
             defaultWeekBudget: retryMergedDefaultWB ?? undefined,
+            fixedCostItems: retryMergedFCI,
+            fixedCostAmountChanges: retryMergedFCC,
           };
           await uploadFile(retryData, retryDownload.rev);
         }
@@ -209,6 +310,20 @@ export async function performSync(): Promise<void> {
       .map((wb) => wb.weekStart);
     if (deletedWBKeys.length > 0) {
       await db.weekBudgets.bulkDelete(deletedWBKeys);
+    }
+
+    const deletedFCIIds = mergedFixedCostItems
+      .filter((i) => i.deleted)
+      .map((i) => i.id);
+    if (deletedFCIIds.length > 0) {
+      await db.fixedCostItems.bulkDelete(deletedFCIIds);
+    }
+
+    const deletedFCCIds = mergedFixedCostChanges
+      .filter((c) => c.deleted)
+      .map((c) => c.id);
+    if (deletedFCCIds.length > 0) {
+      await db.fixedCostAmountChanges.bulkDelete(deletedFCCIds);
     }
 
     // 7. 最終同期日時を保存

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,11 +19,13 @@ export interface DefaultWeekBudgetSync {
 
 // Dropboxに保存するデータ全体
 export interface SeihinData {
-  version: 1 | 2 | 3;
+  version: 1 | 2 | 3 | 4;
   updatedAt: string; // ISO 8601 datetime
   expenses: Expense[];
   weekBudgets?: WeekBudget[]; // v3で追加（後方互換のためoptional）
   defaultWeekBudget?: DefaultWeekBudgetSync; // v3で追加（後方互換のためoptional）
+  fixedCostItems?: FixedCostItem[]; // v4で追加（後方互換のためoptional）
+  fixedCostAmountChanges?: FixedCostAmountChange[]; // v4で追加（後方互換のためoptional）
 }
 
 // メタデータ（IndexedDB用）
@@ -42,3 +44,25 @@ export interface WeekBudget {
 
 // カレンダー表示モード
 export type CalendarViewMode = 'weekly' | 'current-week' | 'simple';
+
+// 月固定費の項目マスター（家賃、光熱費、サブスクなど）
+export interface FixedCostItem {
+  id: string; // crypto.randomUUID()
+  name: string; // 項目名（例: "家賃"）
+  initialAmount: number; // 項目作成時の金額（startYearMonth 以降で変更がない月に適用）
+  startYearMonth: string; // "YYYY-MM"（この月から項目が出現・適用される）
+  endYearMonth?: string; // "YYYY-MM"（この月から項目が表示されなくなる。未設定 = 恒久）
+  order: number; // 表示順
+  updatedAt: string; // ISO 8601 datetime（同期マージ用）
+  deleted?: boolean; // 論理削除（完全削除用、同期マージに使用。通常の「削除」操作では endYearMonth を使う）
+}
+
+// 月固定費の金額変更履歴（effective-from 方式: 指定月以降に適用）
+export interface FixedCostAmountChange {
+  id: string; // crypto.randomUUID()
+  itemId: string; // FixedCostItem.id への参照
+  effectiveYearMonth: string; // "YYYY-MM" 形式（この月から適用）
+  amount: number; // 適用金額（円）
+  updatedAt: string; // ISO 8601 datetime
+  deleted?: boolean; // 削除フラグ（同期用）
+}

--- a/src/utils/fixedCost.test.ts
+++ b/src/utils/fixedCost.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatYearMonth,
+  currentYearMonth,
+  isPastYearMonth,
+  resolveAmountForMonth,
+  resolveMonthlyFixedCosts,
+  sumMonthlyFixedCosts,
+} from './fixedCost';
+import type { FixedCostAmountChange, FixedCostItem } from '../types';
+
+function createItem(overrides: Partial<FixedCostItem> = {}): FixedCostItem {
+  return {
+    id: 'item-1',
+    name: '家賃',
+    initialAmount: 80000,
+    startYearMonth: '1970-01',
+    order: 0,
+    updatedAt: '2026-04-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function createChange(
+  overrides: Partial<FixedCostAmountChange> = {},
+): FixedCostAmountChange {
+  return {
+    id: 'change-1',
+    itemId: 'item-1',
+    effectiveYearMonth: '2026-05',
+    amount: 10000,
+    updatedAt: '2026-04-15T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('formatYearMonth', () => {
+  it('月番号を0埋めする', () => {
+    expect(formatYearMonth(2026, 0)).toBe('2026-01');
+    expect(formatYearMonth(2026, 8)).toBe('2026-09');
+    expect(formatYearMonth(2026, 11)).toBe('2026-12');
+  });
+});
+
+describe('currentYearMonth', () => {
+  it('指定した日付の年月を返す', () => {
+    expect(currentYearMonth(new Date('2026-04-24T00:00:00Z'))).toBe('2026-04');
+  });
+});
+
+describe('isPastYearMonth', () => {
+  const now = new Date('2026-04-24T00:00:00Z');
+
+  it('当月より前は true', () => {
+    expect(isPastYearMonth('2026-03', now)).toBe(true);
+    expect(isPastYearMonth('2025-12', now)).toBe(true);
+  });
+
+  it('当月は false', () => {
+    expect(isPastYearMonth('2026-04', now)).toBe(false);
+  });
+
+  it('未来月は false', () => {
+    expect(isPastYearMonth('2026-05', now)).toBe(false);
+    expect(isPastYearMonth('2027-01', now)).toBe(false);
+  });
+});
+
+describe('resolveAmountForMonth', () => {
+  it('変更履歴がない場合、initialAmount を返す', () => {
+    const item = createItem({ initialAmount: 80000 });
+    const result = resolveAmountForMonth(item, [], '2026-05');
+    expect(result.amount).toBe(80000);
+    expect(result.changedFrom).toBeUndefined();
+  });
+
+  it('発効月より前の月は initialAmount を返す', () => {
+    const item = createItem({ initialAmount: 8000 });
+    const changes = [createChange({ effectiveYearMonth: '2026-05', amount: 10000 })];
+    const result = resolveAmountForMonth(item, changes, '2026-04');
+    expect(result.amount).toBe(8000);
+    expect(result.changedFrom).toBeUndefined();
+  });
+
+  it('発効月と同じ月は変更後の金額を返す', () => {
+    const item = createItem({ initialAmount: 8000 });
+    const changes = [createChange({ effectiveYearMonth: '2026-05', amount: 10000 })];
+    const result = resolveAmountForMonth(item, changes, '2026-05');
+    expect(result.amount).toBe(10000);
+    expect(result.changedFrom).toBe('2026-05');
+  });
+
+  it('発効月以降は変更後の金額を引き継ぐ', () => {
+    const item = createItem({ initialAmount: 8000 });
+    const changes = [createChange({ effectiveYearMonth: '2026-05', amount: 10000 })];
+    const result = resolveAmountForMonth(item, changes, '2026-08');
+    expect(result.amount).toBe(10000);
+    expect(result.changedFrom).toBe('2026-05');
+  });
+
+  it('複数の変更履歴があれば、対象月以前で最も新しい発効月を採用する', () => {
+    const item = createItem({ initialAmount: 8000 });
+    const changes = [
+      createChange({ id: 'c1', effectiveYearMonth: '2026-05', amount: 10000 }),
+      createChange({ id: 'c2', effectiveYearMonth: '2026-09', amount: 12000 }),
+    ];
+    expect(resolveAmountForMonth(item, changes, '2026-04').amount).toBe(8000);
+    expect(resolveAmountForMonth(item, changes, '2026-05').amount).toBe(10000);
+    expect(resolveAmountForMonth(item, changes, '2026-08').amount).toBe(10000);
+    expect(resolveAmountForMonth(item, changes, '2026-09').amount).toBe(12000);
+    expect(resolveAmountForMonth(item, changes, '2027-01').amount).toBe(12000);
+  });
+
+  it('deleted の変更履歴は無視される', () => {
+    const item = createItem({ initialAmount: 8000 });
+    const changes = [
+      createChange({ effectiveYearMonth: '2026-05', amount: 10000, deleted: true }),
+    ];
+    const result = resolveAmountForMonth(item, changes, '2026-06');
+    expect(result.amount).toBe(8000);
+    expect(result.changedFrom).toBeUndefined();
+  });
+
+  it('他の itemId の変更履歴は無視される', () => {
+    const item = createItem({ id: 'item-1', initialAmount: 8000 });
+    const changes = [
+      createChange({ itemId: 'item-2', effectiveYearMonth: '2026-05', amount: 99999 }),
+    ];
+    const result = resolveAmountForMonth(item, changes, '2026-06');
+    expect(result.amount).toBe(8000);
+  });
+
+  it('同じ発効月に複数レコードがある場合、updatedAt が新しい方を採用する', () => {
+    const item = createItem({ initialAmount: 8000 });
+    const changes = [
+      createChange({
+        id: 'c1',
+        effectiveYearMonth: '2026-05',
+        amount: 10000,
+        updatedAt: '2026-04-15T00:00:00Z',
+      }),
+      createChange({
+        id: 'c2',
+        effectiveYearMonth: '2026-05',
+        amount: 11000,
+        updatedAt: '2026-04-20T00:00:00Z',
+      }),
+    ];
+    const result = resolveAmountForMonth(item, changes, '2026-05');
+    expect(result.amount).toBe(11000);
+  });
+});
+
+describe('resolveMonthlyFixedCosts', () => {
+  it('複数項目をorder順に解決する', () => {
+    const items = [
+      createItem({ id: 'a', name: '電気代', order: 1, initialAmount: 8000 }),
+      createItem({ id: 'b', name: '家賃', order: 0, initialAmount: 80000 }),
+    ];
+    const result = resolveMonthlyFixedCosts(items, [], '2026-05');
+    expect(result).toHaveLength(2);
+    expect(result[0].item.name).toBe('家賃');
+    expect(result[0].amount).toBe(80000);
+    expect(result[1].item.name).toBe('電気代');
+    expect(result[1].amount).toBe(8000);
+  });
+
+  it('deleted の項目は除外される', () => {
+    const items = [
+      createItem({ id: 'a', order: 0, deleted: true }),
+      createItem({ id: 'b', order: 1 }),
+    ];
+    const result = resolveMonthlyFixedCosts(items, [], '2026-05');
+    expect(result).toHaveLength(1);
+    expect(result[0].item.id).toBe('b');
+  });
+
+  it('startYearMonth より前の月では項目が表示されない', () => {
+    const items = [
+      createItem({ id: 'a', order: 0, startYearMonth: '2026-05' }),
+    ];
+    expect(resolveMonthlyFixedCosts(items, [], '2026-04')).toHaveLength(0);
+    expect(resolveMonthlyFixedCosts(items, [], '2026-05')).toHaveLength(1);
+    expect(resolveMonthlyFixedCosts(items, [], '2026-06')).toHaveLength(1);
+  });
+
+  it('endYearMonth 以降は項目が表示されない（過去月には残る）', () => {
+    const items = [
+      createItem({
+        id: 'a',
+        order: 0,
+        startYearMonth: '2026-01',
+        endYearMonth: '2026-06',
+      }),
+    ];
+    expect(resolveMonthlyFixedCosts(items, [], '2026-05')).toHaveLength(1);
+    expect(resolveMonthlyFixedCosts(items, [], '2026-06')).toHaveLength(0);
+    expect(resolveMonthlyFixedCosts(items, [], '2026-07')).toHaveLength(0);
+    expect(resolveMonthlyFixedCosts(items, [], '2025-12')).toHaveLength(0); // startYearMonth より前
+  });
+
+  it('start === end の場合、どの月にも表示されない（実質的に削除）', () => {
+    const items = [
+      createItem({
+        id: 'a',
+        order: 0,
+        startYearMonth: '2026-05',
+        endYearMonth: '2026-05',
+      }),
+    ];
+    expect(resolveMonthlyFixedCosts(items, [], '2026-04')).toHaveLength(0);
+    expect(resolveMonthlyFixedCosts(items, [], '2026-05')).toHaveLength(0);
+    expect(resolveMonthlyFixedCosts(items, [], '2026-06')).toHaveLength(0);
+  });
+
+  it('startYearMonthごとに有効月が違う複数項目を正しく扱う', () => {
+    const items = [
+      createItem({ id: 'rent', order: 0, startYearMonth: '2026-01', initialAmount: 80000 }),
+      createItem({ id: 'sub', order: 1, startYearMonth: '2026-05', initialAmount: 1500 }),
+    ];
+    const apr = resolveMonthlyFixedCosts(items, [], '2026-04');
+    expect(apr).toHaveLength(1);
+    expect(apr[0].item.id).toBe('rent');
+
+    const may = resolveMonthlyFixedCosts(items, [], '2026-05');
+    expect(may).toHaveLength(2);
+  });
+
+  it('変更履歴を項目ごとに反映する', () => {
+    const items = [
+      createItem({ id: 'a', order: 0, initialAmount: 80000 }),
+      createItem({ id: 'b', order: 1, initialAmount: 8000 }),
+    ];
+    const changes = [
+      createChange({ itemId: 'b', effectiveYearMonth: '2026-05', amount: 10000 }),
+    ];
+    const result = resolveMonthlyFixedCosts(items, changes, '2026-06');
+    expect(result[0].amount).toBe(80000); // 家賃は変更なし
+    expect(result[1].amount).toBe(10000); // 電気代は変更
+    expect(result[1].changedFrom).toBe('2026-05');
+  });
+});
+
+describe('sumMonthlyFixedCosts', () => {
+  it('resolvedの金額合計を返す', () => {
+    const resolved = [
+      { item: createItem({ id: 'a' }), amount: 80000 },
+      { item: createItem({ id: 'b' }), amount: 10000 },
+    ];
+    expect(sumMonthlyFixedCosts(resolved)).toBe(90000);
+  });
+
+  it('空配列なら0を返す', () => {
+    expect(sumMonthlyFixedCosts([])).toBe(0);
+  });
+});

--- a/src/utils/fixedCost.ts
+++ b/src/utils/fixedCost.ts
@@ -1,0 +1,94 @@
+import type { FixedCostAmountChange, FixedCostItem } from '../types';
+
+export interface ResolvedFixedCost {
+  item: FixedCostItem;
+  amount: number;
+  changedFrom?: string; // 適用中の変更レコードの effectiveYearMonth（初期金額のままなら undefined）
+}
+
+// 年月文字列を正規化（"YYYY-M" → "YYYY-MM"）。比較は辞書順で行うため0埋め必須。
+export function formatYearMonth(year: number, month0Based: number): string {
+  const mm = String(month0Based + 1).padStart(2, '0');
+  return `${year}-${mm}`;
+}
+
+// "YYYY-MM" を日本語表示用の "YYYY年M月" に整形
+export function formatYearMonthLabel(yearMonth: string): string {
+  const [year, month] = yearMonth.split('-');
+  return `${year}年${parseInt(month, 10)}月`;
+}
+
+// 今日の年月を "YYYY-MM" で返す
+export function currentYearMonth(now: Date = new Date()): string {
+  return formatYearMonth(now.getFullYear(), now.getMonth());
+}
+
+// 指定年月が今月より前（過去月）かを返す
+export function isPastYearMonth(
+  yearMonth: string,
+  now: Date = new Date(),
+): boolean {
+  return yearMonth < currentYearMonth(now);
+}
+
+// 指定月における項目の金額を解決する
+// - その月以前で最も新しい effectiveYearMonth の amount を採用
+// - 同月に複数レコードがある場合は updatedAt が新しい方を採用
+// - 該当なしなら initialAmount
+export function resolveAmountForMonth(
+  item: FixedCostItem,
+  changes: FixedCostAmountChange[],
+  yearMonth: string,
+): { amount: number; changedFrom?: string } {
+  const applicable = changes
+    .filter(
+      (c) =>
+        c.itemId === item.id &&
+        !c.deleted &&
+        c.effectiveYearMonth <= yearMonth,
+    )
+    .sort((a, b) => {
+      if (a.effectiveYearMonth !== b.effectiveYearMonth) {
+        return b.effectiveYearMonth.localeCompare(a.effectiveYearMonth);
+      }
+      return b.updatedAt.localeCompare(a.updatedAt);
+    });
+
+  const latest = applicable[0];
+  if (!latest) {
+    return { amount: item.initialAmount };
+  }
+  return { amount: latest.amount, changedFrom: latest.effectiveYearMonth };
+}
+
+// 特定月の全項目の解決結果
+// - deleted: true の項目は除外（完全削除）
+// - startYearMonth > yearMonth（まだ発効していない月）の項目も除外
+// - endYearMonth <= yearMonth（終了した月以降）の項目も除外
+export function resolveMonthlyFixedCosts(
+  items: FixedCostItem[],
+  changes: FixedCostAmountChange[],
+  yearMonth: string,
+): ResolvedFixedCost[] {
+  return items
+    .filter(
+      (i) =>
+        !i.deleted &&
+        i.startYearMonth <= yearMonth &&
+        (!i.endYearMonth || yearMonth < i.endYearMonth),
+    )
+    .sort((a, b) => a.order - b.order)
+    .map((item) => {
+      const { amount, changedFrom } = resolveAmountForMonth(
+        item,
+        changes,
+        yearMonth,
+      );
+      return { item, amount, changedFrom };
+    });
+}
+
+// 月の合計固定費
+export function sumMonthlyFixedCosts(resolved: ResolvedFixedCost[]): number {
+  return resolved.reduce((sum, r) => sum + r.amount, 0);
+}


### PR DESCRIPTION
## Summary

- 月単位の固定費（家賃・光熱費・サブスクなど）を複数項目で管理できる機能を追加
- effective-from 方式の金額変更履歴により、月ごとの金額変更を「この月以降」として正確に引き継ぐ
- サマリーページで追加・編集・削除を統合ダイアログで完結
- 過去月は編集不可とし、削除は「その月以降消える」挙動で過去データを保護
- Dropbox 同期にも対応（`SeihinData` v4）
- 月次タブをデフォルト表示に変更

## 主な変更

### データモデル
- 新規テーブル 2 つを追加
  - `fixedCostItems`: 項目マスター（名前・初期金額・開始/終了月）
  - `fixedCostAmountChanges`: 金額変更履歴（itemId × effectiveYearMonth）
- Dexie マイグレーション v7 → v8 → v9

### UI
- [src/components/Summary/MonthlySummary.tsx](src/components/Summary/MonthlySummary.tsx) に固定費の内訳・合計・「月合計 + 固定費」の表示を追加
- [src/components/Summary/FixedCostItemDialog.tsx](src/components/Summary/FixedCostItemDialog.tsx) を新設し、追加・名前変更・金額変更・削除・変更取り消しを1画面で
- 過去月では編集・追加ボタンを非表示
- 月次タブをデフォルト表示に

### ロジック
- [src/utils/fixedCost.ts](src/utils/fixedCost.ts) に解決ロジック（純関数）
  - `resolveAmountForMonth`: 指定月の金額を履歴から解決
  - `resolveMonthlyFixedCosts`: 有効な項目のみを出力（startYearMonth / endYearMonth / deleted を考慮）
- [src/hooks/useFixedCosts.ts](src/hooks/useFixedCosts.ts) に CRUD Hook
  - `setAmountForMonth` は常に effective change を作成（initialAmount を破壊的に書き換えない）
  - `endFixedCostItem` は `startYearMonth === yearMonth` のとき関連変更履歴も連動して論理削除

### 同期
- [src/services/sync.ts](src/services/sync.ts) に `mergeFixedCostItems` / `mergeFixedCostAmountChanges` を追加
- 既存の `mergeExpenses` / `mergeWeekBudgets` と同じ id + updatedAt ベースのマージ
- 論理削除レコードの物理削除も拡張

## Test plan

- [ ] 新規項目追加 → 表示中の月以降に表示される
- [ ] 金額変更 → その月以降に引き継がれる
- [ ] 別月で再変更 → 直近の発効月が優先される
- [ ] 「この月の変更を取り消す」→ 前の金額に戻る
- [ ] 削除（`startYearMonth === yearMonth`）→ 完全削除、関連変更履歴も消える
- [ ] 削除（それ以降の月）→ 過去月には残り、その月以降は非表示
- [ ] 過去月で編集・追加ボタンが非表示
- [ ] Dropbox 同期で新テーブルが保存・復元される
- [ ] 月次タブがデフォルト表示
- [ ] `npm test`（125 件）・`npm run build` が通る

## 関連 Issue

レビュー中に発見された既存 sync 実装のバグ（本PRスコープ外、別途対応）:
- #24 同期アップロード失敗時に lastSync が更新され未同期を成功扱いしてしまう
- #25 同期時のトランザクション外 bulkDelete で削除済みレコードが一瞬参照可能になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)