### PR TITLE
feat: 月サマリー改良とJSONインポート機能を追加

### DIFF
--- a/src/components/Settings/SettingsView.tsx
+++ b/src/components/Settings/SettingsView.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import {
   Box,
   Button,
@@ -11,15 +11,22 @@ import {
   ListItemText,
   ListItemIcon,
   TextField,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
 } from '@mui/material';
 import CloudIcon from '@mui/icons-material/Cloud';
 import CloudOffIcon from '@mui/icons-material/CloudOff';
 import SyncIcon from '@mui/icons-material/Sync';
 import DownloadIcon from '@mui/icons-material/Download';
+import UploadIcon from '@mui/icons-material/Upload';
 import { getAuthUrl, disconnect } from '../../services/dropbox';
 import { db } from '../../services/db';
 import { useDefaultWeekBudget, setDefaultWeekBudget } from '../../hooks/useWeekBudget';
 import { formatCurrency } from '../../utils/format';
+import type { SeihinData } from '../../types';
 
 interface SettingsViewProps {
   onSync: () => void;
@@ -44,6 +51,11 @@ export function SettingsView({
   const defaultWeekBudget = useDefaultWeekBudget();
   const [budgetInput, setBudgetInput] = useState<string>('');
   const [budgetError, setBudgetError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [importPreview, setImportPreview] = useState<SeihinData | null>(null);
+  const [importError, setImportError] = useState<string | null>(null);
+  const [importSuccess, setImportSuccess] = useState<string | null>(null);
+  const [importing, setImporting] = useState(false);
 
   const handleDropboxConnect = async () => {
     try {
@@ -97,6 +109,96 @@ export function SettingsView({
     a.download = `seihin-export-${new Date().toISOString().slice(0, 10)}.json`;
     a.click();
     URL.revokeObjectURL(url);
+  };
+
+  const handleImportClick = () => {
+    setImportError(null);
+    setImportSuccess(null);
+    fileInputRef.current?.click();
+  };
+
+  const handleFileSelected = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    // 同じファイルを再選択できるよう値をリセット
+    e.target.value = '';
+    if (!file) return;
+
+    try {
+      const text = await file.text();
+      const parsed = JSON.parse(text) as SeihinData;
+
+      // 最低限のバリデーション
+      if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.expenses)) {
+        throw new Error('不正なJSON形式: expenses配列が見つかりません');
+      }
+      setImportPreview(parsed);
+    } catch (err) {
+      setImportError(err instanceof Error ? err.message : 'JSON解析に失敗しました');
+    }
+  };
+
+  const handleImportConfirm = async () => {
+    if (!importPreview) return;
+    setImporting(true);
+    try {
+      // bulkPut でIDベースのupsert（既存データは同一IDのみ上書き、それ以外は保持）
+      await db.transaction(
+        'rw',
+        [
+          db.expenses,
+          db.weekBudgets,
+          db.fixedCostItems,
+          db.fixedCostAmountChanges,
+          db.metadata,
+        ],
+        async () => {
+          if (importPreview.expenses?.length) {
+            await db.expenses.bulkPut(importPreview.expenses);
+          }
+          if (importPreview.weekBudgets?.length) {
+            await db.weekBudgets.bulkPut(importPreview.weekBudgets);
+          }
+          if (importPreview.fixedCostItems?.length) {
+            await db.fixedCostItems.bulkPut(importPreview.fixedCostItems);
+          }
+          if (importPreview.fixedCostAmountChanges?.length) {
+            await db.fixedCostAmountChanges.bulkPut(
+              importPreview.fixedCostAmountChanges,
+            );
+          }
+          if (importPreview.defaultWeekBudget) {
+            await db.metadata.put({
+              key: 'defaultWeekBudget',
+              value: JSON.stringify(importPreview.defaultWeekBudget),
+            });
+          }
+        },
+      );
+      const counts = [
+        `支出${importPreview.expenses.length}件`,
+        importPreview.weekBudgets?.length
+          ? `週予算${importPreview.weekBudgets.length}件`
+          : null,
+        importPreview.fixedCostItems?.length
+          ? `固定費項目${importPreview.fixedCostItems.length}件`
+          : null,
+        importPreview.fixedCostAmountChanges?.length
+          ? `金額変更${importPreview.fixedCostAmountChanges.length}件`
+          : null,
+      ]
+        .filter(Boolean)
+        .join('・');
+      setImportSuccess(`インポート完了: ${counts}`);
+      setImportPreview(null);
+      onDataChanged?.();
+    } catch (err) {
+      setImportError(
+        err instanceof Error ? err.message : 'インポートに失敗しました',
+      );
+      setImportPreview(null);
+    } finally {
+      setImporting(false);
+    }
   };
 
   const formatLastSync = (iso: string | null) => {
@@ -226,18 +328,87 @@ export function SettingsView({
 
       <Divider sx={{ my: 2 }} />
 
-      {/* データエクスポート */}
+      {/* データエクスポート / インポート */}
       <Typography variant="subtitle1" fontWeight="bold" gutterBottom>
-        データエクスポート
+        データエクスポート / インポート
       </Typography>
-      <Button
-        variant="outlined"
-        size="small"
-        onClick={handleExport}
-        startIcon={<DownloadIcon />}
+      <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+        <Button
+          variant="outlined"
+          size="small"
+          onClick={handleExport}
+          startIcon={<DownloadIcon />}
+        >
+          JSONエクスポート
+        </Button>
+        <Button
+          variant="outlined"
+          size="small"
+          onClick={handleImportClick}
+          startIcon={<UploadIcon />}
+        >
+          JSONインポート
+        </Button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="application/json,.json"
+          onChange={handleFileSelected}
+          style={{ display: 'none' }}
+        />
+      </Box>
+      {importError && (
+        <Alert severity="error" sx={{ mt: 1 }} onClose={() => setImportError(null)}>
+          {importError}
+        </Alert>
+      )}
+      {importSuccess && (
+        <Alert severity="success" sx={{ mt: 1 }} onClose={() => setImportSuccess(null)}>
+          {importSuccess}
+        </Alert>
+      )}
+
+      {/* インポート確認ダイアログ */}
+      <Dialog
+        open={importPreview !== null}
+        onClose={() => !importing && setImportPreview(null)}
       >
-        JSONエクスポート
-      </Button>
+        <DialogTitle>JSONインポートの確認</DialogTitle>
+        <DialogContent>
+          <DialogContentText component="div">
+            以下のデータを現在のDBに追加・更新します（同一IDは上書き）。
+            <Box component="ul" sx={{ mt: 1, mb: 0, pl: 2 }}>
+              <li>バージョン: v{importPreview?.version ?? '?'}</li>
+              <li>支出: {importPreview?.expenses.length ?? 0} 件</li>
+              {importPreview?.weekBudgets !== undefined && (
+                <li>週予算: {importPreview.weekBudgets.length} 件</li>
+              )}
+              {importPreview?.fixedCostItems !== undefined && (
+                <li>固定費項目: {importPreview.fixedCostItems.length} 件</li>
+              )}
+              {importPreview?.fixedCostAmountChanges !== undefined && (
+                <li>固定費金額変更: {importPreview.fixedCostAmountChanges.length} 件</li>
+              )}
+              {importPreview?.defaultWeekBudget && (
+                <li>デフォルト週予算: あり</li>
+              )}
+            </Box>
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setImportPreview(null)} disabled={importing}>
+            キャンセル
+          </Button>
+          <Button
+            onClick={handleImportConfirm}
+            variant="contained"
+            disabled={importing}
+            startIcon={importing ? <CircularProgress size={16} /> : undefined}
+          >
+            インポート実行
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   );
 }

--- a/src/components/Summary/ExpenseListSection.tsx
+++ b/src/components/Summary/ExpenseListSection.tsx
@@ -17,11 +17,13 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import type { Expense } from '../../types';
 import { formatCurrency } from '../../utils/format';
-import { getCategoryById } from '../../constants/categories';
+import { CATEGORIES, getCategoryById, type CategoryId } from '../../constants/categories';
 
 interface ExpenseListSectionProps {
   expenses: Expense[];
 }
+
+type CategoryFilter = 'all' | CategoryId;
 
 // 日付でグループ化して降順に並べる
 function groupByDate(expenses: Expense[]): Map<string, Expense[]> {
@@ -43,12 +45,20 @@ function formatDateLabel(dateStr: string): string {
 
 export function ExpenseListSection({ expenses }: ExpenseListSectionProps) {
   const [open, setOpen] = useState(false);
+  const [categoryFilter, setCategoryFilter] = useState<CategoryFilter>('all');
 
   if (expenses.length === 0) return null;
 
-  // メモ付きの支出数
+  // カテゴリフィルタ適用
+  const visibleExpenses =
+    categoryFilter === 'all'
+      ? expenses
+      : expenses.filter((e) => e.category === categoryFilter);
+
+  // メモ付きの支出数（ヘッダー表示はフィルタ前の全件ベースで揃える）
   const withMemo = expenses.filter((e) => e.memo && e.memo !== '（なし）').length;
-  const grouped = groupByDate(expenses);
+  const filteredTotal = visibleExpenses.reduce((sum, e) => sum + e.amount, 0);
+  const grouped = groupByDate(visibleExpenses);
 
   return (
     <>
@@ -63,121 +73,169 @@ export function ExpenseListSection({ expenses }: ExpenseListSectionProps) {
         {open ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
       </ListItemButton>
       <Collapse in={open}>
-        <TableContainer sx={{ px: 1, pb: 1 }}>
-          <Table size="small" sx={{ '& td, & th': { py: 0.5, px: 0.75 } }}>
-            <TableHead>
-              <TableRow>
-                <TableCell sx={{ fontWeight: 'bold', fontSize: '0.75rem', color: 'text.secondary' }}>
-                  日付
-                </TableCell>
-                <TableCell sx={{ fontWeight: 'bold', fontSize: '0.75rem', color: 'text.secondary' }}>
-                  カテゴリ
-                </TableCell>
-                <TableCell align="right" sx={{ fontWeight: 'bold', fontSize: '0.75rem', color: 'text.secondary' }}>
-                  金額
-                </TableCell>
-                <TableCell sx={{ fontWeight: 'bold', fontSize: '0.75rem', color: 'text.secondary' }}>
-                  メモ
-                </TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {[...grouped.entries()].map(([date, items]) => {
-                const dayTotal = items.reduce((sum, e) => sum + e.amount, 0);
-                return items.map((expense, idx) => {
-                  const cat = getCategoryById(expense.category);
-                  const isLastInGroup = idx === items.length - 1;
-                  return (
-                    <TableRow
-                      key={expense.id}
-                      sx={{
-                        // ストライプ背景（日付グループ単位で交互）
-                        backgroundColor: [...grouped.keys()].indexOf(date) % 2 === 0
-                          ? 'transparent'
-                          : 'action.hover',
-                        // グループ最終行の下に区切り線
-                        ...(isLastInGroup && {
-                          '& td': { borderBottom: '2px solid', borderBottomColor: 'divider' },
-                        }),
-                      }}
-                    >
-                      {/* 日付セル: グループの最初の行だけ表示 */}
-                      <TableCell
+        {/* カテゴリフィルタ */}
+        <Box sx={{ px: 2, py: 1, display: 'flex', flexWrap: 'wrap', gap: 0.5, alignItems: 'center' }}>
+          <Chip
+            label="すべて"
+            size="small"
+            variant={categoryFilter === 'all' ? 'filled' : 'outlined'}
+            color={categoryFilter === 'all' ? 'primary' : 'default'}
+            onClick={() => setCategoryFilter('all')}
+            sx={{ fontSize: '0.7rem', height: 22 }}
+          />
+          {CATEGORIES.map((cat) => {
+            const isSelected = categoryFilter === cat.id;
+            return (
+              <Chip
+                key={cat.id}
+                label={cat.label}
+                size="small"
+                variant={isSelected ? 'filled' : 'outlined'}
+                onClick={() => setCategoryFilter(cat.id)}
+                sx={{
+                  fontSize: '0.7rem',
+                  height: 22,
+                  backgroundColor: isSelected ? cat.color : 'transparent',
+                  color: isSelected ? '#fff' : 'text.primary',
+                  borderColor: cat.color,
+                  '&:hover': {
+                    backgroundColor: isSelected ? cat.color : `${cat.color}22`,
+                  },
+                }}
+              />
+            );
+          })}
+          {categoryFilter !== 'all' && (
+            <Typography variant="caption" color="text.secondary" sx={{ ml: 'auto' }}>
+              {visibleExpenses.length}件・{formatCurrency(filteredTotal)}
+            </Typography>
+          )}
+        </Box>
+        {visibleExpenses.length === 0 ? (
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{ textAlign: 'center', py: 2 }}
+          >
+            該当する支出はありません
+          </Typography>
+        ) : (
+          <TableContainer sx={{ px: 1, pb: 1 }}>
+            <Table size="small" sx={{ '& td, & th': { py: 0.5, px: 0.75 } }}>
+              <TableHead>
+                <TableRow>
+                  <TableCell sx={{ fontWeight: 'bold', fontSize: '0.75rem', color: 'text.secondary' }}>
+                    日付
+                  </TableCell>
+                  <TableCell sx={{ fontWeight: 'bold', fontSize: '0.75rem', color: 'text.secondary' }}>
+                    カテゴリ
+                  </TableCell>
+                  <TableCell align="right" sx={{ fontWeight: 'bold', fontSize: '0.75rem', color: 'text.secondary' }}>
+                    金額
+                  </TableCell>
+                  <TableCell sx={{ fontWeight: 'bold', fontSize: '0.75rem', color: 'text.secondary' }}>
+                    メモ
+                  </TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {[...grouped.entries()].map(([date, items]) => {
+                  const dayTotal = items.reduce((sum, e) => sum + e.amount, 0);
+                  return items.map((expense, idx) => {
+                    const cat = getCategoryById(expense.category);
+                    const isLastInGroup = idx === items.length - 1;
+                    return (
+                      <TableRow
+                        key={expense.id}
                         sx={{
-                          fontSize: '0.75rem',
-                          whiteSpace: 'nowrap',
-                          verticalAlign: 'top',
-                          ...(idx > 0 && { borderBottom: 'none' }),
+                          // ストライプ背景（日付グループ単位で交互）
+                          backgroundColor: [...grouped.keys()].indexOf(date) % 2 === 0
+                            ? 'transparent'
+                            : 'action.hover',
+                          // グループ最終行の下に区切り線
+                          ...(isLastInGroup && {
+                            '& td': { borderBottom: '2px solid', borderBottomColor: 'divider' },
+                          }),
                         }}
                       >
-                        {idx === 0 ? formatDateLabel(date) : ''}
-                      </TableCell>
-                      <TableCell>
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                          <Chip
-                            label={cat.label}
-                            size="small"
-                            sx={{
-                              backgroundColor: cat.color,
-                              color: '#fff',
-                              fontSize: '0.65rem',
-                              height: 18,
-                            }}
-                          />
-                          {expense.isSpecial && (
+                        {/* 日付セル: グループの最初の行だけ表示 */}
+                        <TableCell
+                          sx={{
+                            fontSize: '0.75rem',
+                            whiteSpace: 'nowrap',
+                            verticalAlign: 'top',
+                            ...(idx > 0 && { borderBottom: 'none' }),
+                          }}
+                        >
+                          {idx === 0 ? formatDateLabel(date) : ''}
+                        </TableCell>
+                        <TableCell>
+                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                             <Chip
-                              label="⭐️"
+                              label={cat.label}
                               size="small"
-                              color="warning"
-                              sx={{ fontSize: '0.6rem', height: 18 }}
+                              sx={{
+                                backgroundColor: cat.color,
+                                color: '#fff',
+                                fontSize: '0.65rem',
+                                height: 18,
+                              }}
                             />
-                          )}
-                        </Box>
-                      </TableCell>
-                      <TableCell align="right" sx={{ fontSize: '0.8rem', whiteSpace: 'nowrap' }}>
-                        {formatCurrency(expense.amount)}
-                      </TableCell>
-                      <TableCell
+                            {expense.isSpecial && (
+                              <Chip
+                                label="⭐️"
+                                size="small"
+                                color="warning"
+                                sx={{ fontSize: '0.6rem', height: 18 }}
+                              />
+                            )}
+                          </Box>
+                        </TableCell>
+                        <TableCell align="right" sx={{ fontSize: '0.8rem', whiteSpace: 'nowrap' }}>
+                          {formatCurrency(expense.amount)}
+                        </TableCell>
+                        <TableCell
+                          sx={{
+                            fontSize: '0.7rem',
+                            color: expense.memo && expense.memo !== '（なし）' ? 'text.primary' : 'text.disabled',
+                            maxWidth: 120,
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          {expense.memo || ''}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  }).concat(
+                    // 日ごとの小計行
+                    items.length > 1 ? [(
+                      <TableRow
+                        key={`subtotal-${date}`}
                         sx={{
-                          fontSize: '0.7rem',
-                          color: expense.memo && expense.memo !== '（なし）' ? 'text.primary' : 'text.disabled',
-                          maxWidth: 120,
-                          overflow: 'hidden',
-                          textOverflow: 'ellipsis',
-                          whiteSpace: 'nowrap',
+                          backgroundColor: [...grouped.keys()].indexOf(date) % 2 === 0
+                            ? 'transparent'
+                            : 'action.hover',
+                          '& td': { borderBottom: '2px solid', borderBottomColor: 'divider' },
                         }}
                       >
-                        {expense.memo || ''}
-                      </TableCell>
-                    </TableRow>
+                        <TableCell />
+                        <TableCell align="right" sx={{ fontSize: '0.7rem', color: 'text.secondary' }}>
+                          小計
+                        </TableCell>
+                        <TableCell align="right" sx={{ fontSize: '0.8rem', fontWeight: 'bold' }}>
+                          {formatCurrency(dayTotal)}
+                        </TableCell>
+                        <TableCell />
+                      </TableRow>
+                    )] : [],
                   );
-                }).concat(
-                  // 日ごとの小計行
-                  items.length > 1 ? [(
-                    <TableRow
-                      key={`subtotal-${date}`}
-                      sx={{
-                        backgroundColor: [...grouped.keys()].indexOf(date) % 2 === 0
-                          ? 'transparent'
-                          : 'action.hover',
-                        '& td': { borderBottom: '2px solid', borderBottomColor: 'divider' },
-                      }}
-                    >
-                      <TableCell />
-                      <TableCell align="right" sx={{ fontSize: '0.7rem', color: 'text.secondary' }}>
-                        小計
-                      </TableCell>
-                      <TableCell align="right" sx={{ fontSize: '0.8rem', fontWeight: 'bold' }}>
-                        {formatCurrency(dayTotal)}
-                      </TableCell>
-                      <TableCell />
-                    </TableRow>
-                  )] : [],
-                );
-              })}
-            </TableBody>
-          </Table>
-        </TableContainer>
+                })}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
       </Collapse>
     </>
   );

--- a/src/components/Summary/MonthlySummary.tsx
+++ b/src/components/Summary/MonthlySummary.tsx
@@ -1,14 +1,26 @@
 import { useState } from 'react';
-import { Box, IconButton, Typography, List, ListItem, ListItemText, Divider, Button } from '@mui/material';
+import {
+  Box,
+  IconButton,
+  Typography,
+  List,
+  ListItem,
+  ListItemText,
+  ListItemButton,
+  Divider,
+  Button,
+  Collapse,
+} from '@mui/material';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import TodayIcon from '@mui/icons-material/Today';
 import EditIcon from '@mui/icons-material/Edit';
 import AddIcon from '@mui/icons-material/Add';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import { useExpensesByMonth } from '../../hooks/useExpenses';
 import { useMonthlyFixedCosts } from '../../hooks/useFixedCosts';
 import { formatCurrency } from '../../utils/format';
-import { toDateString } from '../../utils/date';
 import {
   formatYearMonth,
   formatYearMonthLabel,
@@ -19,48 +31,6 @@ import { CategoryDonutChart } from './CategoryDonutChart';
 import { ExpenseListSection } from './ExpenseListSection';
 import { FixedCostItemDialog } from './FixedCostItemDialog';
 import type { FixedCostItem } from '../../types';
-
-interface WeekBreakdown {
-  label: string;
-  total: number;
-}
-
-// 月の日付を月曜始まりの週に分割する
-function getWeekBreakdowns(
-  year: number,
-  month: number,
-  expensesByDate: Map<string, number>,
-): WeekBreakdown[] {
-  const lastDay = new Date(year, month + 1, 0).getDate();
-  const weeks: WeekBreakdown[] = [];
-  let weekNum = 1;
-  let weekStart = 1;
-
-  for (let d = 1; d <= lastDay; d++) {
-    const date = new Date(year, month, d);
-    const dayOfWeek = date.getDay();
-    // 日曜（0）が週の最終日、または月末
-    const isEndOfWeek = dayOfWeek === 0;
-    const isLastDay = d === lastDay;
-
-    if (isEndOfWeek || isLastDay) {
-      let total = 0;
-      for (let i = weekStart; i <= d; i++) {
-        const dateStr = toDateString(new Date(year, month, i));
-        total += expensesByDate.get(dateStr) ?? 0;
-      }
-
-      const m = month + 1;
-      const label = `第${weekNum}週 (${m}/${weekStart}-${m}/${d})`;
-      weeks.push({ label, total });
-
-      weekNum++;
-      weekStart = d + 1;
-    }
-  }
-
-  return weeks;
-}
 
 interface MonthlySummaryProps {
   includeSpecial: boolean;
@@ -74,6 +44,7 @@ export function MonthlySummary({ includeSpecial }: MonthlySummaryProps) {
     useState<'add' | 'edit' | null>(null);
   const [fixedCostDialogItem, setFixedCostDialogItem] =
     useState<FixedCostItem | null>(null);
+  const [fixedCostOpen, setFixedCostOpen] = useState(false);
 
   const expenses = useExpensesByMonth(year, month);
   const yearMonth = formatYearMonth(year, month);
@@ -86,7 +57,7 @@ export function MonthlySummary({ includeSpecial }: MonthlySummaryProps) {
   const prevYear = month === 0 ? year - 1 : year;
   const prevMonthExpenses = useExpensesByMonth(prevYear, prevMonth);
 
-  // 特別な支出のフィルタリング
+  // 特別な支出のフィルタリング（集計用）
   const filteredExpenses = includeSpecial
     ? expenses
     : expenses.filter(e => !e.isSpecial);
@@ -107,14 +78,6 @@ export function MonthlySummary({ includeSpecial }: MonthlySummaryProps) {
   const isCurrentMonth = year === today.getFullYear() && month === today.getMonth();
   const daysForAverage = isCurrentMonth ? today.getDate() : lastDayOfMonth;
   const dailyAverage = daysForAverage > 0 ? Math.floor(monthTotal / daysForAverage) : 0;
-
-  // 日付ごとの金額マップ
-  const expensesByDate = new Map<string, number>();
-  for (const e of filteredExpenses) {
-    expensesByDate.set(e.date, (expensesByDate.get(e.date) ?? 0) + e.amount);
-  }
-
-  const weekBreakdowns = getWeekBreakdowns(year, month, expensesByDate);
 
   // カテゴリ別集計
   const categoryTotals = aggregateByCategory(filteredExpenses);
@@ -203,90 +166,85 @@ export function MonthlySummary({ includeSpecial }: MonthlySummaryProps) {
       {/* カテゴリ別ドーナツチャート */}
       <CategoryDonutChart categoryTotals={categoryTotals} total={monthTotal} />
 
-      <Divider>
-        <Typography variant="caption">週ごとの内訳</Typography>
-      </Divider>
-
-      {/* 週ごとの内訳 */}
-      <List dense>
-        {weekBreakdowns.map((week) => (
-          <ListItem key={week.label}>
-            <ListItemText primary={week.label} />
-            <Typography variant="body2">{formatCurrency(week.total)}</Typography>
-          </ListItem>
-        ))}
-      </List>
-
-      {/* 月固定費の内訳 */}
+      {/* 月固定費の内訳（折りたたみ） */}
       {(fixedCosts.length > 0 || !isPast) && (
         <>
-          <Divider>
-            <Typography variant="caption">固定費の内訳</Typography>
-          </Divider>
-          {fixedCosts.length > 0 ? (
-            <List dense>
-              {fixedCosts.map(({ item, amount, changedFrom }) => (
-                <ListItem
-                  key={item.id}
-                  secondaryAction={
-                    !isPast && (
-                      <IconButton
-                        edge="end"
-                        size="small"
-                        onClick={() => {
-                          setFixedCostDialogItem(item);
-                          setFixedCostDialogMode('edit');
-                        }}
-                        aria-label={`${item.name}を編集`}
-                      >
-                        <EditIcon fontSize="small" />
-                      </IconButton>
-                    )
-                  }
-                >
-                  <ListItemText
-                    primary={item.name}
-                    secondary={
-                      changedFrom
-                        ? `${formatYearMonthLabel(changedFrom)}以降の金額`
-                        : '初期金額'
-                    }
-                  />
-                  <Typography variant="body2" sx={{ mr: isPast ? 0 : 5 }}>
-                    {formatCurrency(amount)}
-                  </Typography>
-                </ListItem>
-              ))}
-            </List>
-          ) : (
-            <Typography
-              variant="body2"
-              color="text.secondary"
-              sx={{ textAlign: 'center', py: 2 }}
-            >
-              固定費は登録されていません
+          <Divider sx={{ mt: 1 }} />
+          <ListItemButton
+            onClick={() => setFixedCostOpen(!fixedCostOpen)}
+            sx={{ py: 1, px: 2, justifyContent: 'space-between' }}
+          >
+            <Typography variant="body2" color="text.secondary">
+              固定費の内訳（{fixedCosts.length}件・{formatCurrency(fixedCostTotal)}）
             </Typography>
-          )}
-          {!isPast && (
-            <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
-              <Button
-                size="small"
-                variant="outlined"
-                startIcon={<AddIcon />}
-                onClick={() => {
-                  setFixedCostDialogItem(null);
-                  setFixedCostDialogMode('add');
-                }}
+            {fixedCostOpen ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+          </ListItemButton>
+          <Collapse in={fixedCostOpen}>
+            {fixedCosts.length > 0 ? (
+              <List dense>
+                {fixedCosts.map(({ item, amount, changedFrom }) => (
+                  <ListItem
+                    key={item.id}
+                    secondaryAction={
+                      !isPast && (
+                        <IconButton
+                          edge="end"
+                          size="small"
+                          onClick={() => {
+                            setFixedCostDialogItem(item);
+                            setFixedCostDialogMode('edit');
+                          }}
+                          aria-label={`${item.name}を編集`}
+                        >
+                          <EditIcon fontSize="small" />
+                        </IconButton>
+                      )
+                    }
+                  >
+                    <ListItemText
+                      primary={item.name}
+                      secondary={
+                        changedFrom
+                          ? `${formatYearMonthLabel(changedFrom)}以降の金額`
+                          : '初期金額'
+                      }
+                    />
+                    <Typography variant="body2" sx={{ mr: isPast ? 0 : 5 }}>
+                      {formatCurrency(amount)}
+                    </Typography>
+                  </ListItem>
+                ))}
+              </List>
+            ) : (
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ textAlign: 'center', py: 2 }}
               >
-                項目を追加
-              </Button>
-            </Box>
-          )}
+                固定費は登録されていません
+              </Typography>
+            )}
+            {!isPast && (
+              <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  startIcon={<AddIcon />}
+                  onClick={() => {
+                    setFixedCostDialogItem(null);
+                    setFixedCostDialogMode('add');
+                  }}
+                >
+                  項目を追加
+                </Button>
+              </Box>
+            )}
+          </Collapse>
         </>
       )}
 
-      {/* 支出一覧（メモ確認用） */}
-      <ExpenseListSection expenses={filteredExpenses} />
+      {/* 支出一覧（特別な支出を除外中も全件表示・カテゴリフィルタあり） */}
+      <ExpenseListSection expenses={expenses} />
 
       <FixedCostItemDialog
         open={fixedCostDialogMode !== null}


### PR DESCRIPTION
## Summary

- **月サマリーのUI改良** (MonthlySummary.tsx / ExpenseListSection.tsx)
  - 週ごとの内訳を削除
  - 固定費の内訳を折りたたみ式に変更（デフォルト閉じた状態、件数・合計額はヘッダーに表示）
  - 支出一覧にカテゴリフィルタ（チップ選択）を追加
  - 「特別な支出を除く」ON時も支出一覧には全件表示（⭐️マーク付き）
- **JSONインポート機能** (SettingsView.tsx)
  - 設定画面に「JSONインポート」ボタンを追加
  - エクスポートJSON（v1〜v4）を読み込み、確認ダイアログで件数提示後に取り込み
  - `bulkPut` によるIDベース upsert で既存データを保持しつつ同一IDのみ上書き
  - `expenses` / `weekBudgets` / `fixedCostItems` / `fixedCostAmountChanges` / `defaultWeekBudget` の全テーブルに対応
  - 単一トランザクションでアトミックに書き込み

## Why

月サマリーは情報量を増やしつつ「普段使わない情報」を折りたたむことで可読性を上げた。カテゴリフィルタは支出の振り返りで特定カテゴリだけ見たいというニーズに対応。JSONインポートは実運用データでUIの動作確認をするために追加。

## レビュー時の注意

- 特別な支出の除外フラグ（`excludeSpecial`）は集計・グラフには従来どおり効くが、**支出一覧への影響は除去**した。これは意図した挙動変更（⭐️付きアイテムも一覧で確認できるほうが便利なため）。
- JSONインポートは upsert 方式のため、既存DBを空にしてからインポートしない限り**古いデータは残る**。テスト後にクリアしたい場合はブラウザのIndexedDBを削除する必要がある。
- `npm run build` / `npm test`（125件）通過。`npm run lint` は既存の `useSync.ts` のエラーのみで本PRのスコープ外。

## Test plan

- [ ] 設定 → JSONインポートで実運用データを取り込み
- [ ] 月サマリー画面で、固定費折りたたみの開閉動作を確認
- [ ] 支出一覧でカテゴリフィルタを切り替えて、件数・合計額表示と空状態を確認
- [ ] 「特別な支出を除く」ONにして、集計値が除外される一方で支出一覧には⭐️付きで表示されることを確認
- [ ] エクスポート → インポート → エクスポート で冪等性を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)