### PR TITLE
feat: サマリーの充実化（特別支出合計・一覧からの編集・カテゴリ別前月比較）

### DIFF
--- a/src/components/ExpenseDialog/ExpenseDialog.tsx
+++ b/src/components/ExpenseDialog/ExpenseDialog.tsx
@@ -25,14 +25,16 @@ import {
 import { formatCurrency } from '../../utils/format';
 import { CATEGORIES, DEFAULT_CATEGORY } from '../../constants/categories';
 import { useMemoSuggestions } from '../../hooks/useMemoSuggestions';
+import type { Expense } from '../../types';
 
 interface ExpenseDialogProps {
   open: boolean;
   date: string; // "YYYY-MM-DD"
   onClose: () => void;
+  initialEditExpense?: Expense; // ダイアログを開いた直後に指定支出を編集モードにする
 }
 
-export function ExpenseDialog({ open, date, onClose }: ExpenseDialogProps) {
+export function ExpenseDialog({ open, date, onClose, initialEditExpense }: ExpenseDialogProps) {
   const expenses = useExpensesByDate(date);
   const [amount, setAmount] = useState('');
   const [memo, setMemo] = useState('');
@@ -54,6 +56,17 @@ export function ExpenseDialog({ open, date, onClose }: ExpenseDialogProps) {
       setEditingId(null);
     }
   }, [open]);
+
+  // ダイアログを開いたときに編集対象が指定されていればプリセット
+  useEffect(() => {
+    if (open && initialEditExpense) {
+      setEditingId(initialEditExpense.id);
+      setAmount(String(initialEditExpense.amount));
+      setMemo(initialEditExpense.memo);
+      setCategory(initialEditExpense.category);
+      setIsSpecial(initialEditExpense.isSpecial ?? false);
+    }
+  }, [open, initialEditExpense]);
 
   const dayTotal = expenses.reduce((sum, e) => sum + e.amount, 0);
 

--- a/src/components/Summary/ExpenseListSection.tsx
+++ b/src/components/Summary/ExpenseListSection.tsx
@@ -21,6 +21,7 @@ import { CATEGORIES, getCategoryById, type CategoryId } from '../../constants/ca
 
 interface ExpenseListSectionProps {
   expenses: Expense[];
+  onEditExpense?: (expense: Expense) => void;
 }
 
 type CategoryFilter = 'all' | CategoryId;
@@ -43,7 +44,7 @@ function formatDateLabel(dateStr: string): string {
   return `${d.getMonth() + 1}/${d.getDate()}（${weekdays[d.getDay()]}）`;
 }
 
-export function ExpenseListSection({ expenses }: ExpenseListSectionProps) {
+export function ExpenseListSection({ expenses, onEditExpense }: ExpenseListSectionProps) {
   const [open, setOpen] = useState(false);
   const [categoryFilter, setCategoryFilter] = useState<CategoryFilter>('all');
 
@@ -147,6 +148,7 @@ export function ExpenseListSection({ expenses }: ExpenseListSectionProps) {
                     return (
                       <TableRow
                         key={expense.id}
+                        onClick={onEditExpense ? () => onEditExpense(expense) : undefined}
                         sx={{
                           // ストライプ背景（日付グループ単位で交互）
                           backgroundColor: [...grouped.keys()].indexOf(date) % 2 === 0
@@ -155,6 +157,13 @@ export function ExpenseListSection({ expenses }: ExpenseListSectionProps) {
                           // グループ最終行の下に区切り線
                           ...(isLastInGroup && {
                             '& td': { borderBottom: '2px solid', borderBottomColor: 'divider' },
+                          }),
+                          // 編集可能ならクリック可能な見た目に
+                          ...(onEditExpense && {
+                            cursor: 'pointer',
+                            '&:hover': {
+                              backgroundColor: 'action.selected',
+                            },
                           }),
                         }}
                       >

--- a/src/components/Summary/MonthlySummary.tsx
+++ b/src/components/Summary/MonthlySummary.tsx
@@ -10,6 +10,7 @@ import {
   Divider,
   Button,
   Collapse,
+  Chip,
 } from '@mui/material';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
@@ -26,11 +27,12 @@ import {
   formatYearMonthLabel,
   isPastYearMonth,
 } from '../../utils/fixedCost';
-import { aggregateByCategory } from '../../utils/chart';
+import { aggregateByCategory, buildCategoryComparison } from '../../utils/chart';
 import { CategoryDonutChart } from './CategoryDonutChart';
 import { ExpenseListSection } from './ExpenseListSection';
 import { FixedCostItemDialog } from './FixedCostItemDialog';
-import type { FixedCostItem } from '../../types';
+import { ExpenseDialog } from '../ExpenseDialog/ExpenseDialog';
+import type { Expense, FixedCostItem } from '../../types';
 
 interface MonthlySummaryProps {
   includeSpecial: boolean;
@@ -45,6 +47,8 @@ export function MonthlySummary({ includeSpecial }: MonthlySummaryProps) {
   const [fixedCostDialogItem, setFixedCostDialogItem] =
     useState<FixedCostItem | null>(null);
   const [fixedCostOpen, setFixedCostOpen] = useState(false);
+  const [comparisonOpen, setComparisonOpen] = useState(false);
+  const [editingExpense, setEditingExpense] = useState<Expense | null>(null);
 
   const expenses = useExpensesByMonth(year, month);
   const yearMonth = formatYearMonth(year, month);
@@ -68,6 +72,11 @@ export function MonthlySummary({ includeSpecial }: MonthlySummaryProps) {
 
   const monthTotal = filteredExpenses.reduce((sum, e) => sum + e.amount, 0);
 
+  // 特別な支出の合計（トグルに関わらず当月の全特別支出を集計）
+  const specialTotal = expenses
+    .filter((e) => e.isSpecial)
+    .reduce((sum, e) => sum + e.amount, 0);
+
   // 前月の合計
   const prevMonthTotal = filteredPrevMonthExpenses.reduce((sum, e) => sum + e.amount, 0);
   const monthDiff = monthTotal - prevMonthTotal;
@@ -81,6 +90,25 @@ export function MonthlySummary({ includeSpecial }: MonthlySummaryProps) {
 
   // カテゴリ別集計
   const categoryTotals = aggregateByCategory(filteredExpenses);
+  const prevCategoryTotals = aggregateByCategory(filteredPrevMonthExpenses);
+  const categoryComparison = buildCategoryComparison(categoryTotals, prevCategoryTotals);
+
+  // 1日平均の前月比: 期間を揃えて比較する（MTD同士）
+  // 当月進行中の場合、前月も同じ日数分のみを対象にする（例: 今日が4/5なら3/1〜3/5のみ）。
+  // 過去月閲覧時は両月ともフル期間で比較する。
+  const prevMonthLastDay = new Date(prevYear, prevMonth + 1, 0).getDate();
+  const prevDaysForAverage = isCurrentMonth
+    ? Math.min(today.getDate(), prevMonthLastDay)
+    : prevMonthLastDay;
+  const prevMonthTotalForAverage = isCurrentMonth
+    ? filteredPrevMonthExpenses
+        .filter((e) => parseInt(e.date.slice(8, 10), 10) <= prevDaysForAverage)
+        .reduce((sum, e) => sum + e.amount, 0)
+    : prevMonthTotal;
+  const prevDailyAverage = prevDaysForAverage > 0
+    ? Math.floor(prevMonthTotalForAverage / prevDaysForAverage)
+    : 0;
+  const dailyAverageDiff = dailyAverage - prevDailyAverage;
 
   const goToPrevMonth = () => {
     if (month === 0) {
@@ -139,16 +167,35 @@ export function MonthlySummary({ includeSpecial }: MonthlySummaryProps) {
           1日平均: {formatCurrency(dailyAverage)}
         </Typography>
         {prevMonthTotal > 0 && (
+          <>
+            <Typography
+              variant="body2"
+              sx={{
+                color: monthDiff > 0 ? 'error.main' : monthDiff < 0 ? 'success.main' : 'text.secondary',
+                mt: 0.5,
+              }}
+            >
+              前月比（月合計）: {monthDiff > 0 ? '+' : ''}
+              {formatCurrency(monthDiff)} ({monthDiff > 0 ? '+' : ''}
+              {monthDiffPercent}%)
+            </Typography>
+            <Typography
+              variant="body2"
+              sx={{
+                color: dailyAverageDiff > 0 ? 'error.main' : dailyAverageDiff < 0 ? 'success.main' : 'text.secondary',
+              }}
+            >
+              前月比（1日平均）: {dailyAverageDiff > 0 ? '+' : ''}
+              {formatCurrency(dailyAverageDiff)}
+            </Typography>
+          </>
+        )}
+        {specialTotal > 0 && (
           <Typography
             variant="body2"
-            sx={{
-              color: monthDiff > 0 ? 'error.main' : monthDiff < 0 ? 'success.main' : 'text.secondary',
-              mt: 0.5,
-            }}
+            sx={{ mt: 0.5, color: 'warning.main' }}
           >
-            前月比（月合計）: {monthDiff > 0 ? '+' : ''}
-            {formatCurrency(monthDiff)} ({monthDiff > 0 ? '+' : ''}
-            {monthDiffPercent}%)
+            ⭐️ 特別な支出: {formatCurrency(specialTotal)}
           </Typography>
         )}
         {fixedCosts.length > 0 && (
@@ -165,6 +212,98 @@ export function MonthlySummary({ includeSpecial }: MonthlySummaryProps) {
 
       {/* カテゴリ別ドーナツチャート */}
       <CategoryDonutChart categoryTotals={categoryTotals} total={monthTotal} />
+
+      {/* カテゴリ別前月比較（折りたたみ） */}
+      {categoryComparison.length > 0 && prevMonthTotal > 0 && (
+        <>
+          <Divider sx={{ mt: 1 }} />
+          <ListItemButton
+            onClick={() => setComparisonOpen(!comparisonOpen)}
+            sx={{ py: 1, px: 2, justifyContent: 'space-between' }}
+          >
+            <Typography variant="body2" color="text.secondary">
+              前月比較（カテゴリ別）
+            </Typography>
+            {comparisonOpen ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+          </ListItemButton>
+          <Collapse in={comparisonOpen}>
+            <Box sx={{ px: 1, pb: 1 }}>
+              <Box
+                sx={{
+                  display: 'grid',
+                  gridTemplateColumns: 'auto 1fr 1fr 1fr',
+                  gap: 0.5,
+                  alignItems: 'center',
+                  fontSize: '0.75rem',
+                  px: 1,
+                }}
+              >
+                <Box />
+                <Typography variant="caption" color="text.secondary" align="right">
+                  今月
+                </Typography>
+                <Typography variant="caption" color="text.secondary" align="right">
+                  前月
+                </Typography>
+                <Typography variant="caption" color="text.secondary" align="right">
+                  差分
+                </Typography>
+                {categoryComparison.map((row) => {
+                  const diffColor =
+                    row.diff > 0 ? 'error.main'
+                    : row.diff < 0 ? 'success.main'
+                    : 'text.secondary';
+                  const sign = row.diff > 0 ? '+' : '';
+                  const percentText =
+                    row.diffPercent === null
+                      ? '新規'
+                      : `${sign}${row.diffPercent}%`;
+                  return (
+                    <Box key={row.id} sx={{ display: 'contents' }}>
+                      <Chip
+                        label={row.label}
+                        size="small"
+                        sx={{
+                          backgroundColor: row.color,
+                          color: '#fff',
+                          fontSize: '0.65rem',
+                          height: 20,
+                          justifySelf: 'start',
+                        }}
+                      />
+                      <Typography variant="body2" align="right" sx={{ fontSize: '0.8rem' }}>
+                        {formatCurrency(row.current)}
+                      </Typography>
+                      <Typography
+                        variant="body2"
+                        align="right"
+                        color="text.secondary"
+                        sx={{ fontSize: '0.8rem' }}
+                      >
+                        {formatCurrency(row.previous)}
+                      </Typography>
+                      <Box sx={{ textAlign: 'right' }}>
+                        <Typography
+                          variant="body2"
+                          sx={{ color: diffColor, fontSize: '0.8rem', lineHeight: 1.2 }}
+                        >
+                          {sign}{formatCurrency(row.diff)}
+                        </Typography>
+                        <Typography
+                          variant="caption"
+                          sx={{ color: diffColor, fontSize: '0.65rem' }}
+                        >
+                          {percentText}
+                        </Typography>
+                      </Box>
+                    </Box>
+                  );
+                })}
+              </Box>
+            </Box>
+          </Collapse>
+        </>
+      )}
 
       {/* 月固定費の内訳（折りたたみ） */}
       {(fixedCosts.length > 0 || !isPast) && (
@@ -244,7 +383,15 @@ export function MonthlySummary({ includeSpecial }: MonthlySummaryProps) {
       )}
 
       {/* 支出一覧（特別な支出を除外中も全件表示・カテゴリフィルタあり） */}
-      <ExpenseListSection expenses={expenses} />
+      <ExpenseListSection expenses={expenses} onEditExpense={setEditingExpense} />
+
+      {/* 支出編集ダイアログ */}
+      <ExpenseDialog
+        open={editingExpense !== null}
+        date={editingExpense?.date ?? ''}
+        initialEditExpense={editingExpense ?? undefined}
+        onClose={() => setEditingExpense(null)}
+      />
 
       <FixedCostItemDialog
         open={fixedCostDialogMode !== null}

--- a/src/components/Summary/WeeklySummary.tsx
+++ b/src/components/Summary/WeeklySummary.tsx
@@ -11,6 +11,8 @@ import { aggregateByCategory } from '../../utils/chart';
 import { CategoryDonutChart } from './CategoryDonutChart';
 import { DailyBarChart } from './DailyBarChart';
 import { ExpenseListSection } from './ExpenseListSection';
+import { ExpenseDialog } from '../ExpenseDialog/ExpenseDialog';
+import type { Expense } from '../../types';
 
 interface WeeklySummaryProps {
   includeSpecial: boolean;
@@ -20,6 +22,7 @@ export function WeeklySummary({ includeSpecial }: WeeklySummaryProps) {
   const today = new Date();
   const { start: initialStart } = getWeekRange(today);
   const [weekStart, setWeekStart] = useState(initialStart);
+  const [editingExpense, setEditingExpense] = useState<Expense | null>(null);
 
   const weekEnd = new Date(weekStart);
   weekEnd.setDate(weekStart.getDate() + 6);
@@ -85,6 +88,11 @@ export function WeeklySummary({ includeSpecial }: WeeklySummaryProps) {
   const prevWeekTotal = filteredPrevWeekExpenses.reduce((sum, e) => sum + e.amount, 0);
   const weekDiff = weekTotal - prevWeekTotal;
   const weekDiffPercent = prevWeekTotal > 0 ? Math.round((weekDiff / prevWeekTotal) * 100) : 0;
+
+  // 特別な支出の合計（トグルに関わらず当週の全特別支出を集計）
+  const specialTotal = expenses
+    .filter((e) => e.isSpecial)
+    .reduce((sum, e) => sum + e.amount, 0);
 
   // カテゴリ別集計
   const categoryTotals = aggregateByCategory(filteredExpenses);
@@ -201,10 +209,30 @@ export function WeeklySummary({ includeSpecial }: WeeklySummaryProps) {
             {weekDiffPercent}%)
           </Typography>
         )}
+
+        {specialTotal > 0 && (
+          <Typography
+            variant="body2"
+            sx={{
+              color: budgetColor === 'common.white' ? 'common.white' : 'warning.main',
+              mt: 0.5,
+            }}
+          >
+            ⭐️ 特別な支出: {formatCurrency(specialTotal)}
+          </Typography>
+        )}
       </Box>
 
-      {/* 支出一覧（メモ確認用） */}
-      <ExpenseListSection expenses={filteredExpenses} />
+      {/* 支出一覧（特別な支出を除外中も全件表示） */}
+      <ExpenseListSection expenses={expenses} onEditExpense={setEditingExpense} />
+
+      {/* 支出編集ダイアログ */}
+      <ExpenseDialog
+        open={editingExpense !== null}
+        date={editingExpense?.date ?? ''}
+        initialEditExpense={editingExpense ?? undefined}
+        onClose={() => setEditingExpense(null)}
+      />
     </Box>
   );
 }

--- a/src/utils/chart.test.ts
+++ b/src/utils/chart.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { aggregateByCategory, categoryMapToChartData } from './chart';
+import {
+  aggregateByCategory,
+  buildCategoryComparison,
+  categoryMapToChartData,
+} from './chart';
 import type { Expense } from '../types';
 
 // テスト用のExpenseヘルパー
@@ -98,5 +102,75 @@ describe('categoryMapToChartData', () => {
     const result = categoryMapToChartData(totals);
     // CATEGORIES順: food, transport, entertainment, books, living, other
     expect(result.map((r) => r.id)).toEqual(['food', 'books', 'other']);
+  });
+});
+
+describe('buildCategoryComparison', () => {
+  it('両月とも0のカテゴリは結果に含まれない', () => {
+    const current = new Map([['food', 500]]);
+    const previous = new Map([['food', 300]]);
+    const result = buildCategoryComparison(current, previous);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('food');
+  });
+
+  it('差分・差分%を正しく計算する', () => {
+    const current = new Map([['food', 1500]]);
+    const previous = new Map([['food', 1000]]);
+    const [row] = buildCategoryComparison(current, previous);
+    expect(row.current).toBe(1500);
+    expect(row.previous).toBe(1000);
+    expect(row.diff).toBe(500);
+    expect(row.diffPercent).toBe(50);
+  });
+
+  it('前月0の場合、差分%はnull', () => {
+    const current = new Map([['food', 500]]);
+    const previous = new Map<string, number>();
+    const [row] = buildCategoryComparison(current, previous);
+    expect(row.diffPercent).toBeNull();
+    expect(row.diff).toBe(500);
+  });
+
+  it('今月のみ0の場合、前月との差は負になる', () => {
+    const current = new Map<string, number>();
+    const previous = new Map([['transport', 2000]]);
+    const [row] = buildCategoryComparison(current, previous);
+    expect(row.current).toBe(0);
+    expect(row.previous).toBe(2000);
+    expect(row.diff).toBe(-2000);
+    expect(row.diffPercent).toBe(-100);
+  });
+
+  it('差分の絶対値が大きい順にソートされる', () => {
+    const current = new Map([
+      ['food', 1000],
+      ['transport', 500],
+      ['books', 100],
+    ]);
+    const previous = new Map([
+      ['food', 900], // diff +100
+      ['transport', 1000], // diff -500
+      ['books', 50], // diff +50
+    ]);
+    const result = buildCategoryComparison(current, previous);
+    expect(result.map((r) => r.id)).toEqual(['transport', 'food', 'books']);
+  });
+
+  it('両Mapが空なら空配列を返す', () => {
+    expect(buildCategoryComparison(new Map(), new Map())).toEqual([]);
+  });
+
+  it('CATEGORIESに存在しないカテゴリIDは結果から除外される', () => {
+    // 過去に存在したが削除されたカテゴリIDが混入しても、結果には含めない
+    const current = new Map([
+      ['food', 500],
+      ['obsolete_category', 9999],
+    ]);
+    const previous = new Map([
+      ['obsolete_category', 8888],
+    ]);
+    const result = buildCategoryComparison(current, previous);
+    expect(result.map((r) => r.id)).toEqual(['food']);
   });
 });

--- a/src/utils/chart.ts
+++ b/src/utils/chart.ts
@@ -20,3 +20,41 @@ export function categoryMapToChartData(categoryTotals: Map<string, number>) {
     color: cat.color,
   }));
 }
+
+// カテゴリ別前月比較データ（差分の絶対値が大きい順にソート）
+export interface CategoryComparison {
+  id: string;
+  label: string;
+  color: string;
+  current: number;
+  previous: number;
+  diff: number;
+  // 前月が0円（=新規カテゴリ）のときは null、それ以外は整数パーセント
+  diffPercent: number | null;
+}
+
+export function buildCategoryComparison(
+  currentTotals: Map<string, number>,
+  previousTotals: Map<string, number>,
+): CategoryComparison[] {
+  const result: CategoryComparison[] = [];
+  for (const cat of CATEGORIES) {
+    const current = currentTotals.get(cat.id) ?? 0;
+    const previous = previousTotals.get(cat.id) ?? 0;
+    if (current === 0 && previous === 0) continue;
+    const diff = current - previous;
+    const diffPercent = previous > 0 ? Math.round((diff / previous) * 100) : null;
+    result.push({
+      id: cat.id,
+      label: cat.label,
+      color: cat.color,
+      current,
+      previous,
+      diff,
+      diffPercent,
+    });
+  }
+  // 差分の絶対値が大きい順
+  result.sort((a, b) => Math.abs(b.diff) - Math.abs(a.diff));
+  return result;
+}


### PR DESCRIPTION
## Summary

月次・週次サマリーに 3 つの機能を追加:

### 1. 特別な支出の合計行
- `⭐️ 特別な支出: ¥XXX` を月次・週次サマリーの合計ブロックに追加
- 除外トグルの状態に関わらず当月/当週の特別支出を集計
  - 除外ON時: 「除外された額」として確認できる
  - 除外OFF時: 月合計の「内訳」として確認できる

### 2. 支出一覧からの編集機能
- `ExpenseListSection` の行をクリックで既存の `ExpenseDialog` が該当支出の編集モードで立ち上がる
- カテゴリ・金額・メモ・特別フラグをすべて調整可能
- `ExpenseDialog` に `initialEditExpense?: Expense` プロパティを追加（既存の add フロー・date-only 起動は非破壊）
- `WeeklySummary` の支出一覧も `filteredExpenses` → `expenses` に変更し、月次と挙動を統一（特別支出除外中も編集可能）

### 3. カテゴリ別前月比較（月次のみ）
- 新設折りたたみセクション「前月比較（カテゴリ別）」
  - `[カテゴリチップ] [今月] [前月] [差分と%]` の 4 列グリッド
  - 差分の絶対値が大きい順にソート（どのカテゴリが変化に寄与したか一目で分かる）
  - 前月実績なしのカテゴリは「新規」と表示
- 合計ブロックに `前月比（1日平均）` の行を追加
- `buildCategoryComparison()` を `utils/chart.ts` に追加（ユニットテスト7件）

## Why

- 特別支出の合計: 除外トグルがあるのに「いくら除外したのか」を見る手段がなかった
- 一覧からの編集: 支出一覧でカテゴリや金額の誤りに気づいてもカレンダーに戻らないと直せなかった
- カテゴリ別前月比較: 合計の増減しかわからず、どのカテゴリが変化の主因かが分からなかった

## レビュー時の注意

### 1日平均比較の期間揃え（重要）
`前月比（1日平均）` は**MTD（month-to-date）同士**で比較するようにした:

- **当月閲覧時**: 前月も「1日〜今日と同じ日付まで」の支出のみを対象にして同じ日数で割る
  - 例: 今日が4/5なら `(April 1-5 合計 / 5) vs (March 1-5 合計 / 5)`
  - 前月が2月のように日数が少ない場合は `min(今日の日, 前月末日)` で頭打ち
- **過去月閲覧時**: 両月ともフル期間で比較（従来通り）

この処理をしないと「4月5日の時点では April 合計/5 vs March 合計/31」となり、進行中の月が不当に高く見える問題があった。

### その他
- `ExpenseDialog` の `initialEditExpense` は useEffect で open=true のときにプリセット。close 時の既存リセット effect と干渉しない
- `buildCategoryComparison` は CATEGORIES に存在しないカテゴリID（削除済みなど）を無視する挙動をテストで保証
- `npm run build` / `npm test`（132件、+7件）通過

## Test plan

- [ ] 月次サマリーで `⭐️ 特別な支出` が表示される（特別支出がある月のみ）
- [ ] 除外トグルを切り替えても特別支出の合計行の値は変わらない
- [ ] 支出一覧の行クリックで編集ダイアログが開き、フォームに既存値が入っている
- [ ] ダイアログでカテゴリ・金額・メモ・特別フラグを更新して保存できる
- [ ] `前月比較（カテゴリ別）` 折りたたみで各カテゴリの差分が確認できる
- [ ] 前月実績なしのカテゴリが「新規」と表示される
- [ ] 今月閲覧時の `前月比（1日平均）` が前月の同日数ベースで算出される
- [ ] 過去月閲覧時はフル期間での比較になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)