### PR TITLE
サマリー・カレンダーの改善

### DIFF
--- a/src/components/Calendar/CalendarGrid.tsx
+++ b/src/components/Calendar/CalendarGrid.tsx
@@ -3,7 +3,7 @@ import { DayCell } from './DayCell';
 import { WeekSummaryRow } from './WeekSummaryRow';
 import { getMonthDays, isSameDay, WEEKDAY_LABELS, toDateString, getWeekStartString, isInMonth } from '../../utils/date';
 import { useWeekBudget } from '../../hooks/useWeekBudget';
-import type { Expense, CalendarViewMode } from '../../types';
+import type { Expense } from '../../types';
 
 interface CalendarGridProps {
   year: number;
@@ -11,7 +11,6 @@ interface CalendarGridProps {
   expenses: Expense[];
   onDateClick: (dateString: string) => void;
   onWeekBudgetClick: (weekStart: string) => void; // 週予算設定ボタンクリック時
-  viewMode: CalendarViewMode; // 表示モード
 }
 
 // 週ごとのデータ構造
@@ -20,7 +19,7 @@ interface WeekData {
   weekStart: string; // 週開始日（月曜）のYYYY-MM-DD
 }
 
-export function CalendarGrid({ year, month, expenses, onDateClick, onWeekBudgetClick, viewMode }: CalendarGridProps) {
+export function CalendarGrid({ year, month, expenses, onDateClick, onWeekBudgetClick }: CalendarGridProps) {
   const days = getMonthDays(year, month);
   const today = new Date();
 
@@ -40,30 +39,7 @@ export function CalendarGrid({ year, month, expenses, onDateClick, onWeekBudgetC
   }
 
   // 当月に属する日付が1つもない週を除外
-  const validWeeks = weeks.filter(w => w.days.some(d => isInMonth(d, year, month)));
-
-  // モードに応じて表示する週をフィルタリング
-  let displayWeeks = validWeeks;
-
-  if (viewMode === 'current-week') {
-    // 今日が表示中の月に含まれるかチェック
-    const isTodayInCurrentMonth = today.getFullYear() === year && today.getMonth() === month;
-
-    if (isTodayInCurrentMonth) {
-      // 今日が含まれる週を表示
-      const currentWeekStart = getWeekStartString(today);
-      const currentWeek = validWeeks.find(w => w.weekStart === currentWeekStart);
-      if (currentWeek) {
-        displayWeeks = [currentWeek];
-      }
-    } else {
-      // 今日が含まれない月の場合、表示中の月の最初の週を表示
-      const firstWeekWithDates = validWeeks[0];
-      if (firstWeekWithDates) {
-        displayWeeks = [firstWeekWithDates];
-      }
-    }
-  }
+  const displayWeeks = weeks.filter(w => w.days.some(d => isInMonth(d, year, month)));
 
   return (
     <Box>
@@ -112,7 +88,6 @@ export function CalendarGrid({ year, month, expenses, onDateClick, onWeekBudgetC
             dailyTotals={dailyTotals}
             onDateClick={onDateClick}
             onWeekBudgetClick={onWeekBudgetClick}
-            showSummary={viewMode !== 'simple'}
           />
         );
       })}
@@ -130,7 +105,6 @@ interface WeekSectionProps {
   dailyTotals: Map<string, number>;
   onDateClick: (dateString: string) => void;
   onWeekBudgetClick: (weekStart: string) => void;
-  showSummary: boolean; // 週集計行を表示するか
 }
 
 function WeekSection({
@@ -142,7 +116,6 @@ function WeekSection({
   dailyTotals,
   onDateClick,
   onWeekBudgetClick,
-  showSummary,
 }: WeekSectionProps) {
   const weekBudget = useWeekBudget(week.weekStart);
   const todayStr = toDateString(today);
@@ -178,9 +151,8 @@ function WeekSection({
         })}
       </Box>
 
-      {/* 週集計行（シンプルモード以外で表示） */}
-      {showSummary && (
-        <WeekSummaryRow
+      {/* 週集計行 */}
+      <WeekSummaryRow
           weekStart={week.weekStart}
           weekTotal={weekTotal}
           weekBudget={weekBudget}
@@ -188,7 +160,6 @@ function WeekSection({
           isCurrentWeek={isCurrentWeek}
           onBudgetClick={() => onWeekBudgetClick(week.weekStart)}
         />
-      )}
     </Box>
   );
 }

--- a/src/components/Calendar/CalendarView.tsx
+++ b/src/components/Calendar/CalendarView.tsx
@@ -1,10 +1,7 @@
 import { useState } from 'react';
-import { Box, IconButton, Typography, ToggleButton, ToggleButtonGroup, Tooltip, useMediaQuery, useTheme, Paper, Divider, List, ListItem, ListItemText, FormControlLabel, Switch } from '@mui/material';
+import { Box, IconButton, Typography, Tooltip, useMediaQuery, useTheme, Paper, Divider, List, ListItem, ListItemText, FormControlLabel, Switch } from '@mui/material';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
-import ViewWeekIcon from '@mui/icons-material/ViewWeek';
-import TodayIcon from '@mui/icons-material/Today';
-import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import MyLocationIcon from '@mui/icons-material/MyLocation';
 import { CalendarGrid } from './CalendarGrid';
 import { ExpenseDialog } from '../ExpenseDialog/ExpenseDialog';
@@ -15,7 +12,6 @@ import { getMonthDays, toDateString } from '../../utils/date';
 import { formatCurrency } from '../../utils/format';
 import { aggregateByCategory } from '../../utils/chart';
 import { CategoryDonutChart } from '../Summary/CategoryDonutChart';
-import type { CalendarViewMode } from '../../types';
 
 interface CalendarViewProps {
   onDataChanged?: () => void;
@@ -27,7 +23,6 @@ export function CalendarView({ onDataChanged }: CalendarViewProps) {
   const [month, setMonth] = useState(today.getMonth());
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [selectedWeekStart, setSelectedWeekStart] = useState<string | null>(null);
-  const [viewMode, setViewMode] = useState<CalendarViewMode>('weekly');
   const [excludeSpecial, setExcludeSpecial] = usePersistedState('excludeSpecial', false);
   const theme = useTheme();
   const isDesktop = useMediaQuery(theme.breakpoints.up('md'));
@@ -134,38 +129,18 @@ export function CalendarView({ onDataChanged }: CalendarViewProps) {
             </Tooltip>
           </Box>
 
-          {/* モード切り替え */}
-          <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-            <ToggleButtonGroup
-              size="small"
-              value={viewMode}
-              exclusive
-              onChange={(_, newMode) => newMode && setViewMode(newMode)}
-            >
-              <ToggleButton value="weekly">
-                <ViewWeekIcon fontSize="small" />
-              </ToggleButton>
-              <ToggleButton value="current-week">
-                <TodayIcon fontSize="small" />
-              </ToggleButton>
-              <ToggleButton value="simple">
-                <CalendarMonthIcon fontSize="small" />
-              </ToggleButton>
-            </ToggleButtonGroup>
-
-            {/* 特別な支出フィルタ */}
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={excludeSpecial}
-                  onChange={(e) => setExcludeSpecial(e.target.checked)}
-                  size="small"
-                />
-              }
-              label="特別な支出を除く"
-              sx={{ ml: 1, mb: 0 }}
-            />
-          </Box>
+          {/* 特別な支出フィルタ */}
+          <FormControlLabel
+            control={
+              <Switch
+                checked={excludeSpecial}
+                onChange={(e) => setExcludeSpecial(e.target.checked)}
+                size="small"
+              />
+            }
+            label="特別な支出を除く"
+            sx={{ mb: 0 }}
+          />
         </Box>
 
         {/* 月合計（モバイルのみ表示） */}
@@ -190,7 +165,6 @@ export function CalendarView({ onDataChanged }: CalendarViewProps) {
           expenses={filteredExpenses}
           onDateClick={(dateStr) => setSelectedDate(dateStr)}
           onWeekBudgetClick={(weekStart) => setSelectedWeekStart(weekStart)}
-          viewMode={viewMode}
         />
       </Box>
 

--- a/src/components/Calendar/DayCell.tsx
+++ b/src/components/Calendar/DayCell.tsx
@@ -43,13 +43,13 @@ export function DayCell({ date, amount, isToday, otherMonth = false, onClick }: 
       >
         {date.getDate()}
       </Typography>
-      {!future && (
+      {(!future || amount > 0) && (
         <Typography
           variant="caption"
           sx={{
             fontSize: { xs: '0.6rem', sm: '0.65rem', md: '0.7rem' },
             lineHeight: 1.2,
-            color: isToday ? 'inherit' : 'text.secondary',
+            color: isToday ? 'inherit' : future ? 'text.disabled' : 'text.secondary',
           }}
         >
           {formatCurrency(amount)}

--- a/src/components/Summary/ExpenseListSection.tsx
+++ b/src/components/Summary/ExpenseListSection.tsx
@@ -56,8 +56,6 @@ export function ExpenseListSection({ expenses, onEditExpense }: ExpenseListSecti
     .filter((e) => categoryFilter === 'all' || e.category === categoryFilter)
     .filter((e) => !specialOnly || e.isSpecial);
 
-  // メモ付きの支出数（ヘッダー表示はフィルタ前の全件ベースで揃える）
-  const withMemo = expenses.filter((e) => e.memo && e.memo !== '（なし）').length;
   const filteredTotal = visibleExpenses.reduce((sum, e) => sum + e.amount, 0);
   const grouped = groupByDate(visibleExpenses);
 
@@ -69,7 +67,7 @@ export function ExpenseListSection({ expenses, onEditExpense }: ExpenseListSecti
         sx={{ py: 1, px: 2, justifyContent: 'space-between' }}
       >
         <Typography variant="body2" color="text.secondary">
-          支出一覧（{expenses.length}件{withMemo > 0 ? `・メモ${withMemo}件` : ''}）
+          支出一覧（{expenses.length}件）
         </Typography>
         {open ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
       </ListItemButton>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,8 +42,6 @@ export interface WeekBudget {
   deleted?: boolean; // 削除フラグ（同期用）
 }
 
-// カレンダー表示モード
-export type CalendarViewMode = 'weekly' | 'current-week' | 'simple';
 
 // 月固定費の項目マスター（家賃、光熱費、サブスクなど）
 export interface FixedCostItem {


### PR DESCRIPTION
## 変更内容

- サマリー支出一覧に「⭐️ 特別のみ」フィルタを追加（カテゴリフィルタとのAND絞り込み対応）
- サマリー支出一覧ヘッダーからメモ件数表示を削除
- カレンダーで未来日に支払い予定がある場合（amount > 0）も金額を表示（グレー色）
- カレンダーの月シンプル表示・週表示モードを削除し、常に全週+週集計行の表示に固定

---
_Generated by [Claude Code](https://claude.ai/code/session_011sUQh7ZFK76rLyy9T3T5hn)_