### PR TITLE
特別な支出を除くトグルをセンタリング

### DIFF
--- a/src/components/Calendar/CalendarView.tsx
+++ b/src/components/Calendar/CalendarView.tsx
@@ -129,7 +129,10 @@ export function CalendarView({ onDataChanged }: CalendarViewProps) {
             </Tooltip>
           </Box>
 
-          {/* 特別な支出フィルタ */}
+        </Box>
+
+        {/* 特別な支出フィルタ */}
+        <Box sx={{ display: 'flex', justifyContent: 'center', mb: { xs: 1, sm: 2 } }}>
           <FormControlLabel
             control={
               <Switch


### PR DESCRIPTION
カレンダータブの「特別な支出を除く」トグルをヘッダー行から独立させ、全タブで中央揃えに統一。

---
_Generated by [Claude Code](https://claude.ai/code/session_011sUQh7ZFK76rLyy9T3T5hn)_