### PR TITLE
feat: 食費のサブカテゴリ（間食・外食）を追加 (#)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -5,8 +5,8 @@
 - `useExpensesByMonth(year, month)`: 月単位でリアクティブ取得
 - `useExpensesByDate(dateString)`: 日単位でリアクティブ取得
 - `useExpensesByDateRange(start, end)`: 範囲指定でリアクティブ取得
-- `addExpense(date, amount, memo, category, isSpecial)`: 新規追加
-- `updateExpense(id, amount, memo, category, isSpecial)`: 更新
+- `addExpense(date, amount, memo, category, isSpecial, subcategory?)`: 新規追加（subcategoryは食費のサブカテゴリ）
+- `updateExpense(id, amount, memo, category, isSpecial, subcategory?)`: 更新
 - `deleteExpense(id)`: 論理削除
 
 ## hooks/useSync.ts

--- a/src/components/ExpenseDialog/ExpenseDialog.tsx
+++ b/src/components/ExpenseDialog/ExpenseDialog.tsx
@@ -14,6 +14,10 @@ import {
   FormControlLabel,
   Checkbox,
   Autocomplete,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
 } from '@mui/material';
 import { ExpenseItem } from './ExpenseItem';
 import {
@@ -24,6 +28,7 @@ import {
 } from '../../hooks/useExpenses';
 import { formatCurrency } from '../../utils/format';
 import { CATEGORIES, DEFAULT_CATEGORY } from '../../constants/categories';
+import { FOOD_SUBCATEGORIES } from '../../constants/foodSubcategories';
 import { useMemoSuggestions } from '../../hooks/useMemoSuggestions';
 import type { Expense } from '../../types';
 
@@ -39,6 +44,7 @@ export function ExpenseDialog({ open, date, onClose, initialEditExpense }: Expen
   const [amount, setAmount] = useState('');
   const [memo, setMemo] = useState('');
   const [category, setCategory] = useState<string>(DEFAULT_CATEGORY);
+  const [subcategory, setSubcategory] = useState<string>('');
   const [isSpecial, setIsSpecial] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
 
@@ -52,6 +58,7 @@ export function ExpenseDialog({ open, date, onClose, initialEditExpense }: Expen
       setAmount('');
       setMemo('');
       setCategory(DEFAULT_CATEGORY);
+      setSubcategory('');
       setIsSpecial(false);
       setEditingId(null);
     }
@@ -64,9 +71,18 @@ export function ExpenseDialog({ open, date, onClose, initialEditExpense }: Expen
       setAmount(String(initialEditExpense.amount));
       setMemo(initialEditExpense.memo);
       setCategory(initialEditExpense.category);
+      setSubcategory(initialEditExpense.subcategory ?? '');
       setIsSpecial(initialEditExpense.isSpecial ?? false);
     }
   }, [open, initialEditExpense]);
+
+  // 食費以外に切り替えたらサブカテゴリをリセット
+  const handleCategoryChange = (newCategory: string) => {
+    setCategory(newCategory);
+    if (newCategory !== 'food') {
+      setSubcategory('');
+    }
+  };
 
   const dayTotal = expenses.reduce((sum, e) => sum + e.amount, 0);
 
@@ -74,24 +90,28 @@ export function ExpenseDialog({ open, date, onClose, initialEditExpense }: Expen
     const parsedAmount = parseInt(amount, 10);
     if (!parsedAmount || parsedAmount <= 0) return;
 
+    const subcategoryToSave = category === 'food' && subcategory ? subcategory : undefined;
+
     if (editingId) {
-      await updateExpense(editingId, parsedAmount, memo, category, isSpecial);
+      await updateExpense(editingId, parsedAmount, memo, category, isSpecial, subcategoryToSave);
       setEditingId(null);
     } else {
-      await addExpense(date, parsedAmount, memo, category, isSpecial);
+      await addExpense(date, parsedAmount, memo, category, isSpecial, subcategoryToSave);
     }
 
     setAmount('');
     setMemo('');
     setCategory(DEFAULT_CATEGORY);
+    setSubcategory('');
     setIsSpecial(false);
   };
 
-  const handleEdit = (expense: { id: string; amount: number; memo: string; category: string; isSpecial?: boolean }) => {
+  const handleEdit = (expense: { id: string; amount: number; memo: string; category: string; isSpecial?: boolean; subcategory?: string }) => {
     setEditingId(expense.id);
     setAmount(String(expense.amount));
     setMemo(expense.memo);
     setCategory(expense.category);
+    setSubcategory(expense.subcategory ?? '');
     setIsSpecial(expense.isSpecial ?? false);
   };
 
@@ -103,6 +123,7 @@ export function ExpenseDialog({ open, date, onClose, initialEditExpense }: Expen
         setAmount('');
         setMemo('');
         setCategory(DEFAULT_CATEGORY);
+        setSubcategory('');
       }
     }
   };
@@ -112,6 +133,7 @@ export function ExpenseDialog({ open, date, onClose, initialEditExpense }: Expen
     setAmount('');
     setMemo('');
     setCategory(DEFAULT_CATEGORY);
+    setSubcategory('');
     setIsSpecial(false);
   };
 
@@ -137,7 +159,7 @@ export function ExpenseDialog({ open, date, onClose, initialEditExpense }: Expen
               key={cat.id}
               label={cat.label}
               size="small"
-              onClick={() => setCategory(cat.id)}
+              onClick={() => handleCategoryChange(cat.id)}
               sx={{
                 backgroundColor: category === cat.id ? cat.color : 'transparent',
                 color: category === cat.id ? '#fff' : 'text.primary',
@@ -149,6 +171,28 @@ export function ExpenseDialog({ open, date, onClose, initialEditExpense }: Expen
             />
           ))}
         </Box>
+
+        {/* 食費のサブカテゴリ選択（間食の無駄遣いなどを把握するため） */}
+        {category === 'food' && (
+          <FormControl size="small" fullWidth sx={{ mb: 1 }}>
+            <InputLabel id="subcategory-label">サブカテゴリ</InputLabel>
+            <Select
+              labelId="subcategory-label"
+              label="サブカテゴリ"
+              value={subcategory}
+              onChange={(e) => setSubcategory(e.target.value)}
+            >
+              <MenuItem value="">
+                <em>なし</em>
+              </MenuItem>
+              {FOOD_SUBCATEGORIES.map((sub) => (
+                <MenuItem key={sub.id} value={sub.id}>
+                  {sub.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        )}
 
         {/* 特別な支出フラグ */}
         <FormControlLabel

--- a/src/components/ExpenseDialog/ExpenseItem.tsx
+++ b/src/components/ExpenseDialog/ExpenseItem.tsx
@@ -3,6 +3,7 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import type { Expense } from '../../types';
 import { formatCurrency } from '../../utils/format';
 import { getCategoryById } from '../../constants/categories';
+import { getFoodSubcategoryById } from '../../constants/foodSubcategories';
 
 interface ExpenseItemProps {
   expense: Expense;
@@ -12,6 +13,7 @@ interface ExpenseItemProps {
 
 export function ExpenseItem({ expense, onDelete, onEdit }: ExpenseItemProps) {
   const cat = getCategoryById(expense.category);
+  const subcat = getFoodSubcategoryById(expense.subcategory);
 
   return (
     <ListItem
@@ -44,6 +46,19 @@ export function ExpenseItem({ expense, onDelete, onEdit }: ExpenseItemProps) {
                 height: 20,
               }}
             />
+            {subcat && (
+              <Chip
+                label={subcat.label}
+                size="small"
+                variant="outlined"
+                sx={{
+                  borderColor: cat.color,
+                  color: cat.color,
+                  fontSize: '0.7rem',
+                  height: 20,
+                }}
+              />
+            )}
             {expense.isSpecial && (
               <Chip
                 label="★"

--- a/src/components/Summary/ExpenseListSection.tsx
+++ b/src/components/Summary/ExpenseListSection.tsx
@@ -18,6 +18,7 @@ import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import type { Expense } from '../../types';
 import { formatCurrency } from '../../utils/format';
 import { CATEGORIES, getCategoryById, type CategoryId } from '../../constants/categories';
+import { getFoodSubcategoryById } from '../../constants/foodSubcategories';
 
 interface ExpenseListSectionProps {
   expenses: Expense[];
@@ -150,6 +151,7 @@ export function ExpenseListSection({ expenses, onEditExpense }: ExpenseListSecti
                   const dayTotal = items.reduce((sum, e) => sum + e.amount, 0);
                   return items.map((expense, idx) => {
                     const cat = getCategoryById(expense.category);
+                    const subcat = getFoodSubcategoryById(expense.subcategory);
                     const isLastInGroup = idx === items.length - 1;
                     return (
                       <TableRow
@@ -196,6 +198,14 @@ export function ExpenseListSection({ expenses, onEditExpense }: ExpenseListSecti
                                 height: 18,
                               }}
                             />
+                            {subcat && (
+                              <Chip
+                                label={subcat.label}
+                                size="small"
+                                variant="outlined"
+                                sx={{ borderColor: cat.color, color: cat.color, fontSize: '0.6rem', height: 18 }}
+                              />
+                            )}
                             {expense.isSpecial && (
                               <Chip
                                 label="⭐️"

--- a/src/components/Summary/MonthlySummary.tsx
+++ b/src/components/Summary/MonthlySummary.tsx
@@ -27,7 +27,8 @@ import {
   formatYearMonthLabel,
   isPastYearMonth,
 } from '../../utils/fixedCost';
-import { aggregateByCategory, buildCategoryComparison } from '../../utils/chart';
+import { aggregateByCategory, aggregateFoodBySubcategory, buildCategoryComparison } from '../../utils/chart';
+import { FOOD_SUBCATEGORIES } from '../../constants/foodSubcategories';
 import { CategoryDonutChart } from './CategoryDonutChart';
 import { ExpenseListSection } from './ExpenseListSection';
 import { FixedCostItemDialog } from './FixedCostItemDialog';
@@ -92,6 +93,9 @@ export function MonthlySummary({ includeSpecial }: MonthlySummaryProps) {
   const categoryTotals = aggregateByCategory(filteredExpenses);
   const prevCategoryTotals = aggregateByCategory(filteredPrevMonthExpenses);
   const categoryComparison = buildCategoryComparison(categoryTotals, prevCategoryTotals);
+
+  // 食費のサブカテゴリ別集計（間食の無駄遣いを把握するため）
+  const foodSubcategoryTotals = aggregateFoodBySubcategory(filteredExpenses);
 
   // 1日平均の前月比: 期間を揃えて比較する（MTD同士）
   // 当月進行中の場合、前月も同じ日数分のみを対象にする（例: 今日が4/5なら3/1〜3/5のみ）。
@@ -198,6 +202,21 @@ export function MonthlySummary({ includeSpecial }: MonthlySummaryProps) {
             ⭐️ 特別な支出: {formatCurrency(specialTotal)}
           </Typography>
         )}
+        {FOOD_SUBCATEGORIES.map((sub) => {
+          const total = foodSubcategoryTotals.get(sub.id) ?? 0;
+          if (total === 0) return null;
+          const percent = monthTotal > 0 ? Math.round((total / monthTotal) * 100) : 0;
+          return (
+            <Typography
+              key={sub.id}
+              variant="body2"
+              color="text.secondary"
+              sx={{ mt: 0.5 }}
+            >
+              {sub.label}: {formatCurrency(total)}（月合計の{percent}%）
+            </Typography>
+          );
+        })}
         {fixedCosts.length > 0 && (
           <>
             <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>

--- a/src/constants/foodSubcategories.test.ts
+++ b/src/constants/foodSubcategories.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { FOOD_SUBCATEGORIES, getFoodSubcategoryById } from './foodSubcategories';
+
+describe('FOOD_SUBCATEGORIES', () => {
+  it('間食・外食の2つが定義されている', () => {
+    expect(FOOD_SUBCATEGORIES).toHaveLength(2);
+  });
+
+  it('各サブカテゴリがid, labelを持つ', () => {
+    FOOD_SUBCATEGORIES.forEach((sub) => {
+      expect(sub).toHaveProperty('id');
+      expect(sub).toHaveProperty('label');
+      expect(typeof sub.id).toBe('string');
+      expect(typeof sub.label).toBe('string');
+    });
+  });
+});
+
+describe('getFoodSubcategoryById', () => {
+  it('間食サブカテゴリを取得する', () => {
+    expect(getFoodSubcategoryById('snack')).toEqual({ id: 'snack', label: '間食' });
+  });
+
+  it('外食サブカテゴリを取得する', () => {
+    expect(getFoodSubcategoryById('eating_out')).toEqual({ id: 'eating_out', label: '外食' });
+  });
+
+  it('未指定（undefined）の場合はundefinedを返す', () => {
+    expect(getFoodSubcategoryById(undefined)).toBeUndefined();
+  });
+
+  it('存在しないIDの場合はundefinedを返す', () => {
+    expect(getFoodSubcategoryById('nonexistent')).toBeUndefined();
+  });
+});

--- a/src/constants/foodSubcategories.ts
+++ b/src/constants/foodSubcategories.ts
@@ -1,0 +1,13 @@
+// 食費のサブカテゴリ定義（間食の無駄遣いなどを把握するため）
+export const FOOD_SUBCATEGORIES = [
+  { id: 'snack', label: '間食' },
+  { id: 'eating_out', label: '外食' },
+] as const;
+
+export type FoodSubcategoryId = (typeof FOOD_SUBCATEGORIES)[number]['id'];
+
+// IDからサブカテゴリ情報を取得（未分類の場合はundefined）
+export function getFoodSubcategoryById(id: string | undefined) {
+  if (!id) return undefined;
+  return FOOD_SUBCATEGORIES.find((s) => s.id === id);
+}

--- a/src/hooks/useExpenses.ts
+++ b/src/hooks/useExpenses.ts
@@ -55,6 +55,7 @@ export async function addExpense(
   memo: string,
   category: string = DEFAULT_CATEGORY,
   isSpecial: boolean = false,
+  subcategory?: string,
 ): Promise<void> {
   const now = new Date().toISOString();
   await db.expenses.add({
@@ -64,6 +65,7 @@ export async function addExpense(
     memo,
     category,
     isSpecial,
+    subcategory,
     createdAt: now,
     updatedAt: now,
   });
@@ -76,12 +78,14 @@ export async function updateExpense(
   memo: string,
   category: string,
   isSpecial: boolean,
+  subcategory?: string,
 ): Promise<void> {
   await db.expenses.update(id, {
     amount,
     memo,
     category,
     isSpecial,
+    subcategory,
     updatedAt: new Date().toISOString(),
   });
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,7 @@ export interface Expense {
   updatedAt: string; // ISO 8601 datetime
   deleted?: boolean; // 削除フラグ（同期用）
   isSpecial?: boolean; // 特別な支出フラグ（予算外の支出）
+  subcategory?: string; // サブカテゴリID（現状は食費のみ。'snack' | 'eating_out'）
 }
 
 // デフォルト週予算の同期用データ

--- a/src/utils/chart.test.ts
+++ b/src/utils/chart.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   aggregateByCategory,
+  aggregateFoodBySubcategory,
   buildCategoryComparison,
   categoryMapToChartData,
 } from './chart';
@@ -53,6 +54,27 @@ describe('aggregateByCategory', () => {
     ];
     const result = aggregateByCategory(expenses);
     expect(result.get('food')).toBe(500);
+  });
+});
+
+describe('aggregateFoodBySubcategory', () => {
+  it('空配列の場合、空のMapを返す', () => {
+    const result = aggregateFoodBySubcategory([]);
+    expect(result.size).toBe(0);
+  });
+
+  it('食費・サブカテゴリありの支出のみ集計する', () => {
+    const expenses = [
+      createExpense({ id: '1', amount: 300, category: 'food', subcategory: 'snack' }),
+      createExpense({ id: '2', amount: 200, category: 'food', subcategory: 'snack' }),
+      createExpense({ id: '3', amount: 1000, category: 'food', subcategory: 'eating_out' }),
+      createExpense({ id: '4', amount: 500, category: 'food' }), // サブカテゴリなし
+      createExpense({ id: '5', amount: 900, category: 'transport', subcategory: 'snack' }), // 食費以外は無視
+    ];
+    const result = aggregateFoodBySubcategory(expenses);
+    expect(result.get('snack')).toBe(500);
+    expect(result.get('eating_out')).toBe(1000);
+    expect(result.size).toBe(2);
   });
 });
 

--- a/src/utils/chart.ts
+++ b/src/utils/chart.ts
@@ -11,6 +11,16 @@ export function aggregateByCategory(expenses: Expense[]) {
   return categoryTotals;
 }
 
+// 食費のサブカテゴリ別集計（間食などの無駄遣いを把握するため）
+export function aggregateFoodBySubcategory(expenses: Expense[]) {
+  const totals = new Map<string, number>();
+  for (const e of expenses) {
+    if (e.category !== 'food' || !e.subcategory) continue;
+    totals.set(e.subcategory, (totals.get(e.subcategory) ?? 0) + e.amount);
+  }
+  return totals;
+}
+
 // Rechartsのデータ形式に変換
 export function categoryMapToChartData(categoryTotals: Map<string, number>) {
   return CATEGORIES.filter((cat) => categoryTotals.has(cat.id)).map((cat) => ({


### PR DESCRIPTION
食費に間食・外食のサブカテゴリを追加し、サマリー画面の月合計で
サブカテゴリごとの金額と月合計に占める割合を表示できるようにした。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015FPNu4spJ7GGPZsXp5YRNJ