### PR TITLE
fix: サブカテゴリの内訳をカテゴリ別の凡例に表示し割合を非表示に

### DIFF
--- a/src/components/Summary/CategoryDonutChart.tsx
+++ b/src/components/Summary/CategoryDonutChart.tsx
@@ -2,17 +2,21 @@ import { Box, Typography } from '@mui/material';
 import { PieChart, Pie, Cell, ResponsiveContainer, Label } from 'recharts';
 import { categoryMapToChartData } from '../../utils/chart';
 import { formatCurrency } from '../../utils/format';
+import { FOOD_SUBCATEGORIES } from '../../constants/foodSubcategories';
 
 interface CategoryDonutChartProps {
   categoryTotals: Map<string, number>;
   total: number;
   height?: number;
+  // 食費のサブカテゴリ別集計（間食・外食の内訳を「食費」の下に表示するため）
+  foodSubcategoryTotals?: Map<string, number>;
 }
 
 export function CategoryDonutChart({
   categoryTotals,
   total,
   height = 240,
+  foodSubcategoryTotals,
 }: CategoryDonutChartProps) {
   const chartData = categoryMapToChartData(categoryTotals);
 
@@ -58,34 +62,59 @@ export function CategoryDonutChart({
       {/* カスタム凡例 */}
       <Box sx={{ mt: 2, px: 2 }}>
         {chartData.map((item) => (
-          <Box
-            key={item.id}
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-              py: 0.5,
-            }}
-          >
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-              <Box
-                sx={{
-                  width: 12,
-                  height: 12,
-                  backgroundColor: item.color,
-                  borderRadius: '50%',
-                }}
-              />
-              <Typography variant="body2">{item.label}</Typography>
+          <Box key={item.id}>
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                py: 0.5,
+              }}
+            >
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Box
+                  sx={{
+                    width: 12,
+                    height: 12,
+                    backgroundColor: item.color,
+                    borderRadius: '50%',
+                  }}
+                />
+                <Typography variant="body2">{item.label}</Typography>
+              </Box>
+              <Typography variant="body2" fontWeight="medium">
+                {formatCurrency(item.value)}
+                {total > 0 && (
+                  <Typography component="span" variant="body2" color="text.secondary" sx={{ ml: 0.5 }}>
+                    ({Math.round((item.value / total) * 100)}%)
+                  </Typography>
+                )}
+              </Typography>
             </Box>
-            <Typography variant="body2" fontWeight="medium">
-              {formatCurrency(item.value)}
-              {total > 0 && (
-                <Typography component="span" variant="body2" color="text.secondary" sx={{ ml: 0.5 }}>
-                  ({Math.round((item.value / total) * 100)}%)
-                </Typography>
-              )}
-            </Typography>
+            {/* 食費のサブカテゴリ内訳（間食・外食） */}
+            {item.id === 'food' && foodSubcategoryTotals && FOOD_SUBCATEGORIES.map((sub) => {
+              const subTotal = foodSubcategoryTotals.get(sub.id) ?? 0;
+              if (subTotal === 0) return null;
+              return (
+                <Box
+                  key={sub.id}
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    py: 0.25,
+                    pl: 3,
+                  }}
+                >
+                  <Typography variant="caption" color="text.secondary">
+                    {sub.label}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {formatCurrency(subTotal)}
+                  </Typography>
+                </Box>
+              );
+            })}
           </Box>
         ))}
       </Box>

--- a/src/components/Summary/MonthlySummary.tsx
+++ b/src/components/Summary/MonthlySummary.tsx
@@ -28,7 +28,6 @@ import {
   isPastYearMonth,
 } from '../../utils/fixedCost';
 import { aggregateByCategory, aggregateFoodBySubcategory, buildCategoryComparison } from '../../utils/chart';
-import { FOOD_SUBCATEGORIES } from '../../constants/foodSubcategories';
 import { CategoryDonutChart } from './CategoryDonutChart';
 import { ExpenseListSection } from './ExpenseListSection';
 import { FixedCostItemDialog } from './FixedCostItemDialog';
@@ -202,21 +201,6 @@ export function MonthlySummary({ includeSpecial }: MonthlySummaryProps) {
             ⭐️ 特別な支出: {formatCurrency(specialTotal)}
           </Typography>
         )}
-        {FOOD_SUBCATEGORIES.map((sub) => {
-          const total = foodSubcategoryTotals.get(sub.id) ?? 0;
-          if (total === 0) return null;
-          const percent = monthTotal > 0 ? Math.round((total / monthTotal) * 100) : 0;
-          return (
-            <Typography
-              key={sub.id}
-              variant="body2"
-              color="text.secondary"
-              sx={{ mt: 0.5 }}
-            >
-              {sub.label}: {formatCurrency(total)}（月合計の{percent}%）
-            </Typography>
-          );
-        })}
         {fixedCosts.length > 0 && (
           <>
             <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
@@ -230,7 +214,11 @@ export function MonthlySummary({ includeSpecial }: MonthlySummaryProps) {
       </Box>
 
       {/* カテゴリ別ドーナツチャート */}
-      <CategoryDonutChart categoryTotals={categoryTotals} total={monthTotal} />
+      <CategoryDonutChart
+        categoryTotals={categoryTotals}
+        total={monthTotal}
+        foodSubcategoryTotals={foodSubcategoryTotals}
+      />
 
       {/* カテゴリ別前月比較（折りたたみ） */}
       {categoryComparison.length > 0 && prevMonthTotal > 0 && (


### PR DESCRIPTION
## Summary
- 月合計の下にテキストで表示していた食費サブカテゴリ（間食・外食）の内訳を、カテゴリ別ドーナツチャートの凡例内（食費の下）に移動
- 割合表示は削除し、金額のみ表示するよう変更

これは #32 でマージ済みの「食費のサブカテゴリ追加」機能に対するフィードバック対応です。

## Test plan
- [x] `npm run build`
- [x] `npm test`（全140件パス）
- [x] ブラウザで実際に間食・外食の支出を登録し、サマリー画面のカテゴリ別凡例に金額のみ（割合なし）で表示されることを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_015FPNu4spJ7GGPZsXp5YRNJ)_