### PR TITLE
外食・間食の回数を可視化する機能を追加

### DIFF
--- a/src/components/Summary/FoodFrequencyTrendChart.tsx
+++ b/src/components/Summary/FoodFrequencyTrendChart.tsx
@@ -1,0 +1,61 @@
+import { Box, Typography } from '@mui/material';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { FOOD_SUBCATEGORIES } from '../../constants/foodSubcategories';
+import type { MonthlySubcategoryCount } from '../../utils/chart';
+
+// カテゴリ色（食費: #4CAF50）と被らない配色
+const SUBCATEGORY_COLORS: Record<string, string> = {
+  eating_out: '#FF7043',
+  snack: '#26A69A',
+};
+
+interface FoodFrequencyTrendChartProps {
+  data: MonthlySubcategoryCount[];
+  height?: number;
+}
+
+export function FoodFrequencyTrendChart({ data, height = 200 }: FoodFrequencyTrendChartProps) {
+  const hasData = data.some((d) => FOOD_SUBCATEGORIES.some((sub) => d.counts[sub.id] > 0));
+
+  if (!hasData) {
+    return (
+      <Box sx={{ textAlign: 'center', py: 2 }}>
+        <Typography variant="body2" color="text.secondary">
+          この期間の外食・間食の記録はありません
+        </Typography>
+      </Box>
+    );
+  }
+
+  const chartData = data.map((d) => ({ label: d.label, ...d.counts }));
+
+  return (
+    <Box sx={{ width: '100%', my: 1 }}>
+      <ResponsiveContainer width="100%" height={height}>
+        <BarChart data={chartData} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+          <XAxis dataKey="label" tick={{ fontSize: 12 }} axisLine={false} tickLine={false} />
+          <YAxis allowDecimals={false} tick={{ fontSize: 12 }} axisLine={false} tickLine={false} width={24} />
+          <Tooltip
+            formatter={(value: number | undefined, name: string | undefined) => {
+              const sub = FOOD_SUBCATEGORIES.find((s) => s.id === name);
+              return [`${value ?? 0}回`, sub?.label ?? name ?? ''];
+            }}
+          />
+          <Legend
+            formatter={(value: string) => FOOD_SUBCATEGORIES.find((s) => s.id === value)?.label ?? value}
+            wrapperStyle={{ fontSize: 12 }}
+          />
+          {FOOD_SUBCATEGORIES.map((sub) => (
+            <Bar
+              key={sub.id}
+              dataKey={sub.id}
+              fill={SUBCATEGORY_COLORS[sub.id]}
+              isAnimationActive={false}
+              radius={[4, 4, 0, 0]}
+            />
+          ))}
+        </BarChart>
+      </ResponsiveContainer>
+    </Box>
+  );
+}

--- a/src/components/Summary/MonthlySummary.tsx
+++ b/src/components/Summary/MonthlySummary.tsx
@@ -19,20 +19,30 @@ import EditIcon from '@mui/icons-material/Edit';
 import AddIcon from '@mui/icons-material/Add';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
-import { useExpensesByMonth } from '../../hooks/useExpenses';
+import { useExpensesByMonth, useExpensesByDateRange } from '../../hooks/useExpenses';
 import { useMonthlyFixedCosts } from '../../hooks/useFixedCosts';
 import { formatCurrency } from '../../utils/format';
+import { toDateString } from '../../utils/date';
 import {
   formatYearMonth,
   formatYearMonthLabel,
   isPastYearMonth,
 } from '../../utils/fixedCost';
-import { aggregateByCategory, aggregateFoodBySubcategory, buildCategoryComparison } from '../../utils/chart';
+import {
+  aggregateByCategory,
+  aggregateFoodBySubcategory,
+  buildCategoryComparison,
+  buildFoodSubcategoryMonthlyTrend,
+} from '../../utils/chart';
+import { FOOD_SUBCATEGORIES } from '../../constants/foodSubcategories';
 import { CategoryDonutChart } from './CategoryDonutChart';
+import { FoodFrequencyTrendChart } from './FoodFrequencyTrendChart';
 import { ExpenseListSection } from './ExpenseListSection';
 import { FixedCostItemDialog } from './FixedCostItemDialog';
 import { ExpenseDialog } from '../ExpenseDialog/ExpenseDialog';
 import type { Expense, FixedCostItem } from '../../types';
+
+const FREQUENCY_TREND_MONTHS = 6;
 
 interface MonthlySummaryProps {
   includeSpecial: boolean;
@@ -48,6 +58,7 @@ export function MonthlySummary({ includeSpecial }: MonthlySummaryProps) {
     useState<FixedCostItem | null>(null);
   const [fixedCostOpen, setFixedCostOpen] = useState(false);
   const [comparisonOpen, setComparisonOpen] = useState(false);
+  const [frequencyOpen, setFrequencyOpen] = useState(false);
   const [editingExpense, setEditingExpense] = useState<Expense | null>(null);
 
   const expenses = useExpensesByMonth(year, month);
@@ -95,6 +106,27 @@ export function MonthlySummary({ includeSpecial }: MonthlySummaryProps) {
 
   // 食費のサブカテゴリ別集計（間食の無駄遣いを把握するため）
   const foodSubcategoryTotals = aggregateFoodBySubcategory(filteredExpenses);
+
+  // 外食・間食の回数推移（直近6ヶ月、当月含む）
+  const trendRangeStart = new Date(year, month - (FREQUENCY_TREND_MONTHS - 1), 1);
+  const trendRangeEnd = new Date(year, month + 1, 0);
+  const trendExpenses = useExpensesByDateRange(
+    toDateString(trendRangeStart),
+    toDateString(trendRangeEnd),
+  );
+  const filteredTrendExpenses = includeSpecial
+    ? trendExpenses
+    : trendExpenses.filter((e) => !e.isSpecial);
+  const foodFrequencyTrend = buildFoodSubcategoryMonthlyTrend(
+    filteredTrendExpenses,
+    year,
+    month,
+    FREQUENCY_TREND_MONTHS,
+  );
+  const currentMonthFrequency = foodFrequencyTrend[foodFrequencyTrend.length - 1].counts;
+  const hasFrequencyData = foodFrequencyTrend.some((m) =>
+    FOOD_SUBCATEGORIES.some((sub) => m.counts[sub.id] > 0),
+  );
 
   // 1日平均の前月比: 期間を揃えて比較する（MTD同士）
   // 当月進行中の場合、前月も同じ日数分のみを対象にする（例: 今日が4/5なら3/1〜3/5のみ）。
@@ -308,6 +340,32 @@ export function MonthlySummary({ includeSpecial }: MonthlySummaryProps) {
                 })}
               </Box>
             </Box>
+          </Collapse>
+        </>
+      )}
+
+      {/* 外食・間食の回数推移（折りたたみ） */}
+      {hasFrequencyData && (
+        <>
+          <Divider sx={{ mt: 1 }} />
+          <ListItemButton
+            onClick={() => setFrequencyOpen(!frequencyOpen)}
+            sx={{ py: 1, px: 2, justifyContent: 'space-between' }}
+          >
+            <Typography variant="body2" color="text.secondary">
+              外食・間食の回数（
+              {FOOD_SUBCATEGORIES.map(
+                (sub) => `${sub.label} ${currentMonthFrequency[sub.id] ?? 0}回`,
+              ).join('・')}
+              ）
+            </Typography>
+            {frequencyOpen ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+          </ListItemButton>
+          <Collapse in={frequencyOpen}>
+            <Typography variant="caption" color="text.secondary" sx={{ px: 2 }}>
+              直近{FREQUENCY_TREND_MONTHS}ヶ月の推移
+            </Typography>
+            <FoodFrequencyTrendChart data={foodFrequencyTrend} />
           </Collapse>
         </>
       )}

--- a/src/components/Summary/WeeklySummary.tsx
+++ b/src/components/Summary/WeeklySummary.tsx
@@ -7,7 +7,8 @@ import { getWeekRange, toDateString } from '../../utils/date';
 import { useExpensesByDateRange } from '../../hooks/useExpenses';
 import { useWeekBudget } from '../../hooks/useWeekBudget';
 import { formatCurrency } from '../../utils/format';
-import { aggregateByCategory } from '../../utils/chart';
+import { aggregateByCategory, aggregateFoodSubcategoryCount } from '../../utils/chart';
+import { FOOD_SUBCATEGORIES } from '../../constants/foodSubcategories';
 import { CategoryDonutChart } from './CategoryDonutChart';
 import { DailyBarChart } from './DailyBarChart';
 import { ExpenseListSection } from './ExpenseListSection';
@@ -96,6 +97,12 @@ export function WeeklySummary({ includeSpecial }: WeeklySummaryProps) {
 
   // カテゴリ別集計
   const categoryTotals = aggregateByCategory(filteredExpenses);
+
+  // 外食・間食の回数
+  const foodSubcategoryCounts = aggregateFoodSubcategoryCount(filteredExpenses);
+  const hasFoodSubcategoryCounts = FOOD_SUBCATEGORIES.some(
+    (sub) => (foodSubcategoryCounts.get(sub.id) ?? 0) > 0,
+  );
 
   // 平均の分母: 当週なら今日までの日数、過去週なら7
   const todayStr = toDateString(today);
@@ -207,6 +214,18 @@ export function WeeklySummary({ includeSpecial }: WeeklySummaryProps) {
             前週比: {weekDiff > 0 ? '+' : ''}
             {formatCurrency(weekDiff)} ({weekDiff > 0 ? '+' : ''}
             {weekDiffPercent}%)
+          </Typography>
+        )}
+
+        {hasFoodSubcategoryCounts && (
+          <Typography
+            variant="body2"
+            color={budgetColor === 'common.white' ? 'common.white' : 'text.secondary'}
+            sx={{ mt: 0.5 }}
+          >
+            {FOOD_SUBCATEGORIES.map(
+              (sub) => `${sub.label} ${foodSubcategoryCounts.get(sub.id) ?? 0}回`,
+            ).join('・')}
           </Typography>
         )}
 

--- a/src/utils/chart.test.ts
+++ b/src/utils/chart.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect } from 'vitest';
 import {
   aggregateByCategory,
   aggregateFoodBySubcategory,
+  aggregateFoodSubcategoryCount,
   buildCategoryComparison,
+  buildFoodSubcategoryMonthlyTrend,
   categoryMapToChartData,
 } from './chart';
 import type { Expense } from '../types';
@@ -75,6 +77,53 @@ describe('aggregateFoodBySubcategory', () => {
     expect(result.get('snack')).toBe(500);
     expect(result.get('eating_out')).toBe(1000);
     expect(result.size).toBe(2);
+  });
+});
+
+describe('aggregateFoodSubcategoryCount', () => {
+  it('空配列の場合、空のMapを返す', () => {
+    const result = aggregateFoodSubcategoryCount([]);
+    expect(result.size).toBe(0);
+  });
+
+  it('食費・サブカテゴリありの支出のみ回数をカウントする', () => {
+    const expenses = [
+      createExpense({ id: '1', amount: 300, category: 'food', subcategory: 'snack' }),
+      createExpense({ id: '2', amount: 200, category: 'food', subcategory: 'snack' }),
+      createExpense({ id: '3', amount: 1000, category: 'food', subcategory: 'eating_out' }),
+      createExpense({ id: '4', amount: 500, category: 'food' }), // サブカテゴリなし
+      createExpense({ id: '5', amount: 900, category: 'transport', subcategory: 'snack' }), // 食費以外は無視
+    ];
+    const result = aggregateFoodSubcategoryCount(expenses);
+    expect(result.get('snack')).toBe(2);
+    expect(result.get('eating_out')).toBe(1);
+    expect(result.size).toBe(2);
+  });
+});
+
+describe('buildFoodSubcategoryMonthlyTrend', () => {
+  it('指定月数分の月次カウントを古い順で返す（データなしは0）', () => {
+    const result = buildFoodSubcategoryMonthlyTrend([], 2026, 1, 3); // 2026年2月まで3ヶ月分（0-indexed: 1=2月）
+    expect(result.map((m) => m.yearMonth)).toEqual(['2025-12', '2026-01', '2026-02']);
+    expect(result.map((m) => m.label)).toEqual(['12月', '1月', '2月']);
+    for (const m of result) {
+      expect(m.counts).toEqual({ snack: 0, eating_out: 0 });
+    }
+  });
+
+  it('各月の食費サブカテゴリ回数を正しく集計する', () => {
+    const expenses = [
+      createExpense({ id: '1', date: '2026-01-05', category: 'food', subcategory: 'snack' }),
+      createExpense({ id: '2', date: '2026-01-20', category: 'food', subcategory: 'snack' }),
+      createExpense({ id: '3', date: '2026-02-01', category: 'food', subcategory: 'eating_out' }),
+      createExpense({ id: '4', date: '2025-12-31', category: 'food', subcategory: 'eating_out' }),
+      createExpense({ id: '5', date: '2026-01-10', category: 'transport', subcategory: 'snack' }), // 食費以外は無視
+    ];
+    const result = buildFoodSubcategoryMonthlyTrend(expenses, 2026, 1, 3);
+    const [dec, jan, feb] = result;
+    expect(dec.counts).toEqual({ snack: 0, eating_out: 1 });
+    expect(jan.counts).toEqual({ snack: 2, eating_out: 0 });
+    expect(feb.counts).toEqual({ snack: 0, eating_out: 1 });
   });
 });
 

--- a/src/utils/chart.ts
+++ b/src/utils/chart.ts
@@ -1,5 +1,6 @@
 import type { Expense } from '../types';
 import { CATEGORIES } from '../constants/categories';
+import { FOOD_SUBCATEGORIES } from '../constants/foodSubcategories';
 
 // カテゴリ別集計
 export function aggregateByCategory(expenses: Expense[]) {
@@ -19,6 +20,48 @@ export function aggregateFoodBySubcategory(expenses: Expense[]) {
     totals.set(e.subcategory, (totals.get(e.subcategory) ?? 0) + e.amount);
   }
   return totals;
+}
+
+// 食費のサブカテゴリ別回数集計（外食・間食の頻度を把握するため）
+export function aggregateFoodSubcategoryCount(expenses: Expense[]) {
+  const counts = new Map<string, number>();
+  for (const e of expenses) {
+    if (e.category !== 'food' || !e.subcategory) continue;
+    counts.set(e.subcategory, (counts.get(e.subcategory) ?? 0) + 1);
+  }
+  return counts;
+}
+
+export interface MonthlySubcategoryCount {
+  yearMonth: string; // "YYYY-MM"
+  label: string; // "2月"
+  counts: Record<string, number>; // サブカテゴリID -> 回数
+}
+
+// 外食・間食の回数の月次推移（endYear/endMonthを含む直近monthCountヶ月分、古い順）
+// expensesにはあらかじめ対象期間全体の支出を渡す
+export function buildFoodSubcategoryMonthlyTrend(
+  expenses: Expense[],
+  endYear: number,
+  endMonth: number, // 0-indexed
+  monthCount: number,
+): MonthlySubcategoryCount[] {
+  const result: MonthlySubcategoryCount[] = [];
+  for (let i = monthCount - 1; i >= 0; i--) {
+    const d = new Date(endYear, endMonth - i, 1);
+    const y = d.getFullYear();
+    const m = d.getMonth();
+    const ym = `${y}-${String(m + 1).padStart(2, '0')}`;
+    const monthExpenses = expenses.filter((e) => e.date.startsWith(ym));
+    const counts: Record<string, number> = {};
+    for (const sub of FOOD_SUBCATEGORIES) {
+      counts[sub.id] = monthExpenses.filter(
+        (e) => e.category === 'food' && e.subcategory === sub.id,
+      ).length;
+    }
+    result.push({ yearMonth: ym, label: `${m + 1}月`, counts });
+  }
+  return result;
 }
 
 // Rechartsのデータ形式に変換


### PR DESCRIPTION
## Summary
- 食費のサブカテゴリ（間食・外食）は既に記録できていたが、金額のみで回数は可視化されていなかったため対応
- サマリー画面の月次表示に「外食・間食の回数」の折りたたみセクションを追加し、直近6ヶ月の推移を棒グラフで表示
- 週次表示にも当該週の外食・間食の回数をテキストで表示

## Changes
- `src/utils/chart.ts`: `aggregateFoodSubcategoryCount()`（回数集計）、`buildFoodSubcategoryMonthlyTrend()`（月次推移データ生成）を追加
- `src/components/Summary/FoodFrequencyTrendChart.tsx`（新規）: 外食・間食の回数を月別グループ棒グラフで表示
- `src/components/Summary/MonthlySummary.tsx`: 回数推移セクション（折りたたみ、直近6ヶ月）を追加
- `src/components/Summary/WeeklySummary.tsx`: 週合計欄に回数のテキスト表示を追加
- `src/utils/chart.test.ts`: 新規関数のテストを追加

## Test plan
- [x] `npm run build` が通ることを確認
- [x] `npm test` で全144件のテストが通ることを確認（新規4件含む）
- [x] `npm run lint` に既存以外の新規エラーが出ないことを確認
- [x] Playwright + Chromiumで実際にデータを投入し、月次・週次両画面で回数表示が正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VG81QiSGGarf4tQ7tcCTyp

---
_Generated by [Claude Code](https://claude.ai/code/session_01VG81QiSGGarf4tQ7tcCTyp)_